### PR TITLE
[FEATURE] Ask user to send a notification mail to visitors on period update or deletion

### DIFF
--- a/Classes/Command/ArchiveOrdersFromPastPeriodsCommand.php
+++ b/Classes/Command/ArchiveOrdersFromPastPeriodsCommand.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Command;

--- a/Classes/Command/RemoveInactiveOrdersCommand.php
+++ b/Classes/Command/RemoveInactiveOrdersCommand.php
@@ -38,10 +38,19 @@ class RemoveInactiveOrdersCommand extends Command
         $this->setDescription('Remove inactive orders after a given time.');
         $this->setHelp('Remove inactive orders (orders with active = 0) after a given time.');
         $this->addOption('expiration-time', 't', InputOption::VALUE_OPTIONAL, 'Expiration time of an inactive order in seconds', '3600');
+        $this->addOption(
+            'locale',
+            'l',
+            InputOption::VALUE_OPTIONAL,
+            'Locale to be used inside templates and translations. Value that is available inside the Locales class '
+            . '(TYPO3\\CMS\\Core\\Localization\\Locales). Example: "default" for english, "de" for german.',
+            'default'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $GLOBALS['LANG']->init((string)$input->getOption('locale'));
         $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
         /** @var CancellationService $cancellationService */
         $cancellationService = $objectManager->get(CancellationService::class);

--- a/Classes/Command/RemoveInactiveOrdersCommand.php
+++ b/Classes/Command/RemoveInactiveOrdersCommand.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Command;

--- a/Classes/Command/SendMailCommand.php
+++ b/Classes/Command/SendMailCommand.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace JWeiland\Reserve\Command;
+
+use JWeiland\Reserve\Domain\Model\Email;
+use JWeiland\Reserve\Domain\Model\Order;
+use JWeiland\Reserve\Domain\Repository\EmailRepository;
+use JWeiland\Reserve\Utility\MailUtility;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
+
+/**
+ * Command to send mails using all tx_reserve_domain_model_mail records
+ */
+class SendMailCommand extends Command
+{
+    /**
+     * @var EmailRepository
+     */
+    protected $emailRepository;
+
+    /**
+     * @var PersistenceManager
+     */
+    protected $persistenceManager;
+
+    /**
+     * @var Email
+     */
+    protected $email;
+
+    /**
+     * @var array|Order[]
+     */
+    protected $orders = [];
+
+    public function __construct(string $name = null, EmailRepository $emailRepository, PersistenceManager $persistenceManager)
+    {
+        parent::__construct($name);
+        $this->emailRepository = $emailRepository;
+        $this->persistenceManager = $persistenceManager;
+    }
+
+    protected function configure()
+    {
+        $this->setDescription('Send mails using all tx_reserve_domain_model_mail records.');
+        $this->setHelp('Send mails using all tx_reserve_domain_model_mail records.');
+        $this->addOption('limit', 'l', InputOption::VALUE_OPTIONAL, 'How many mails per execution?', 100);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $limit = (int)$input->getArgument('limit');
+        $sentMails = 0;
+        while ($sentMails < $limit) {
+            if (!$this->sendNextMail()) {
+                break;
+            }
+        }
+        if ($sentMails === ($limit - 1)) {
+            // we have run into the limit so save this state
+            $this->unlockAndUpdateProcessedEmail();
+        }
+        return 0;
+    }
+
+    protected function sendNextMail(): bool
+    {
+        if (!$order = $this->getNextOrder()) {
+            // no more mails to send
+            return false;
+        }
+
+        try {
+            MailUtility::sendMailToCustomer(
+                $order,
+                $this->email->getSubject(),
+                $this->email->getBody() // TODO: str_replace('###RESERVATION###', ...) !!!
+            );
+            $this->addOrderToProcessedOrders($order);
+        } catch (\Throwable $throwable) {
+        }
+
+        return true;
+    }
+
+    protected function getNextOrder()
+    {
+        if(empty($this->orders)) {
+            if ($this->email) {
+                // all orders of current email are processed now
+                $this->unlockAndUpdateProcessedEmail();
+            }
+            $this->email = $this->emailRepository->findOneUnlocked();
+            if ($this->email instanceof Email) {
+                // lock current record
+                $this->emailRepository->lockEmail($this->email->getUid());
+                if (!$this->email->getCommandData()) {
+                    $this->email->setCommandData(['processedOrders' => []]);
+                }
+            } else {
+                // no more records in db
+                return null;
+            }
+            foreach ($this->email->getPeriods() as $period) {
+                foreach ($period->getOrders() as $order) {
+                    if (in_array($order->getUid(), $this->email->getCommandData(), true)) {
+                        // already processed
+                        continue;
+                    }
+                    $this->orders[] = $order;
+                }
+            }
+        }
+        return array_shift($this->orders);
+    }
+
+    protected function addOrderToProcessedOrders(Order $order)
+    {
+        $commandData = $this->email->getCommandData();
+        $commandData['processedOrders'][] = $order->getUid();
+        $this->email->setCommandData($commandData);
+    }
+
+    protected function unlockAndUpdateProcessedEmail()
+    {
+        $this->email->setLocked(false);
+        $this->persistenceManager->add($this->email);
+        $this->persistenceManager->persistAll();
+    }
+}

--- a/Classes/Command/SendMailsCommand.php
+++ b/Classes/Command/SendMailsCommand.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Command;
@@ -78,7 +72,7 @@ class SendMailsCommand extends Command
     {
         $this->setDescription('Send mails using all tx_reserve_domain_model_mail records.');
         $this->setHelp('Send mails using all tx_reserve_domain_model_mail records.');
-        $this->addOption('limit', 'm', InputOption::VALUE_OPTIONAL, 'How many mails per execution?', 100);
+        $this->addOption('mailLimit', 'm', InputOption::VALUE_OPTIONAL, 'How many mails per execution?', 100);
         $this->addOption(
             'locale',
             'l',
@@ -92,18 +86,19 @@ class SendMailsCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $GLOBALS['LANG']->init((string)$input->getOption('locale'));
-        $limit = (int)$input->getOption('limit');
+        $mailLimit = (int)$input->getOption('mailLimit');
         $progressBar = new ProgressBar($output);
         $output->writeln('Send mails...');
         $sentMails = 0;
-        while ($sentMails < $limit) {
+        while ($sentMails < $mailLimit) {
             if (!$this->sendNextMail()) {
                 break;
             }
+            $sentMails++;
             $progressBar->advance();
         }
-        if ($sentMails === ($limit - 1)) {
-            // we have run into the limit so save the current process
+        if ($sentMails === ($mailLimit - 1)) {
+            // we have run into the mailLimit so save the current process
             $this->unlockAndUpdateProcessedEmail();
         }
 
@@ -157,7 +152,7 @@ class SendMailsCommand extends Command
 
     protected function getNextReceiver(): string
     {
-        if(empty($this->receivers)) {
+        if (empty($this->receivers)) {
             if ($this->email) {
                 // all orders of current email are processed now
                 $this->unlockAndUpdateProcessedEmail();

--- a/Classes/Command/SendMailsCommand.php
+++ b/Classes/Command/SendMailsCommand.php
@@ -68,11 +68,20 @@ class SendMailsCommand extends Command
     {
         $this->setDescription('Send mails using all tx_reserve_domain_model_mail records.');
         $this->setHelp('Send mails using all tx_reserve_domain_model_mail records.');
-        $this->addOption('limit', 'l', InputOption::VALUE_OPTIONAL, 'How many mails per execution?', 100);
+        $this->addOption('limit', 'm', InputOption::VALUE_OPTIONAL, 'How many mails per execution?', 100);
+        $this->addOption(
+            'locale',
+            'l',
+            InputOption::VALUE_OPTIONAL,
+            'Locale to be used inside templates and translations. Value that is available inside the Locales class '
+            . '(TYPO3\\CMS\\Core\\Localization\\Locales). Example: "default" for english, "de" for german.',
+            'default'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $GLOBALS['LANG']->init((string)$input->getOption('locale'));
         $limit = (int)$input->getOption('limit');
         $progressBar = new ProgressBar($output);
         $output->writeln('Send mails...');

--- a/Classes/Command/SendMailsCommand.php
+++ b/Classes/Command/SendMailsCommand.php
@@ -20,8 +20,8 @@ namespace JWeiland\Reserve\Command;
 use JWeiland\Reserve\Domain\Model\Email;
 use JWeiland\Reserve\Domain\Model\Order;
 use JWeiland\Reserve\Domain\Repository\EmailRepository;
+use JWeiland\Reserve\Service\MailService;
 use JWeiland\Reserve\Utility\FluidUtility;
-use JWeiland\Reserve\Utility\MailUtility;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
@@ -101,7 +101,7 @@ class SendMailsCommand extends Command
         }
 
         try {
-            MailUtility::sendMailToCustomer(
+            GeneralUtility::makeInstance(MailService::class)->sendMailToCustomer(
                 $order,
                 $this->email->getSubject(),
                 FluidUtility::replaceMarkerByRenderedTemplate(

--- a/Classes/Command/SendMailsCommand.php
+++ b/Classes/Command/SendMailsCommand.php
@@ -127,6 +127,7 @@ class SendMailsCommand extends Command
         if(empty($this->orders)) {
             if ($this->email) {
                 // all orders of current email are processed now
+                $this->unlockAndUpdateProcessedEmail();
                 $this->removeProcessedEmail();
             }
             $this->email = $this->emailRepository->findOneUnlocked();
@@ -142,8 +143,11 @@ class SendMailsCommand extends Command
             }
             foreach ($this->email->getPeriods() as $period) {
                 foreach ($period->getOrders() as $order) {
-                    if (in_array($order->getUid(), $this->email->getCommandData(), true)) {
-                        // already processed
+                    if (
+                        $order->getOrderType() === Order::TYPE_ARCHIVED
+                        || in_array($order->getUid(), $this->email->getCommandData(), true)
+                    ) {
+                        // archived or already processed
                         continue;
                     }
                     $this->orders[] = $order;

--- a/Classes/Configuration/ExtConf.php
+++ b/Classes/Configuration/ExtConf.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Configuration;

--- a/Classes/Controller/CheckoutController.php
+++ b/Classes/Controller/CheckoutController.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Controller;

--- a/Classes/Controller/ManagementController.php
+++ b/Classes/Controller/ManagementController.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Controller;

--- a/Classes/Controller/QrCodePreviewController.php
+++ b/Classes/Controller/QrCodePreviewController.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Controller\Backend;

--- a/Classes/Controller/v8/CheckoutController.php
+++ b/Classes/Controller/v8/CheckoutController.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Controller\v8;

--- a/Classes/DataHandler/AskForMailAfterPeriodDeletion.php
+++ b/Classes/DataHandler/AskForMailAfterPeriodDeletion.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\DataHandler;
@@ -81,10 +75,8 @@ class AskForMailAfterPeriodDeletion implements SingletonInterface
             ->leftJoin('p', 'tx_reserve_domain_model_order', 'o', 'o.booked_period = p.uid')
             ->leftJoin('p', 'tx_reserve_domain_model_facility', 'f', 'f.uid = p.facility')
             ->where(
-                $queryBuilder->expr()->andX(
-                    $queryBuilder->expr()->eq('p.uid', $queryBuilder->createNamedParameter($periodUid)),
-                    $queryBuilder->expr()->neq('o.order_type', $queryBuilder->createNamedParameter(Order::TYPE_ARCHIVED))
-                )
+                $queryBuilder->expr()->eq('p.uid', $queryBuilder->createNamedParameter($periodUid)),
+                $queryBuilder->expr()->neq('o.order_type', $queryBuilder->createNamedParameter(Order::TYPE_ARCHIVED))
             )
             ->execute()
             ->fetchAll();

--- a/Classes/DataHandler/AskForMailAfterPeriodDeletion.php
+++ b/Classes/DataHandler/AskForMailAfterPeriodDeletion.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace JWeiland\Reserve\DataHandler;
+
+use JWeiland\Reserve\Domain\Model\Email;
+use JWeiland\Reserve\Domain\Model\Order;
+use JWeiland\Reserve\Hooks\PageRenderer;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+
+class AskForMailAfterPeriodDeletion implements SingletonInterface
+{
+    const TABLE = 'tx_reserve_domain_model_period';
+
+    /**
+     * @var array
+     */
+    protected $visitorEmails = [];
+
+    /**
+     * @var int
+     */
+    protected $pid = 0;
+
+    /**
+     * @var string
+     */
+    protected $fromName = '';
+
+    /**
+     * @var string
+     */
+    protected $fromEmail = '';
+
+    /**
+     * @var string
+     */
+    protected $replyToName = '';
+
+    /**
+     * @var string
+     */
+    protected $replyToEmail = '';
+
+    public function processDataHandlerCmdDeleteAction(string $table, int $id, array $recordToDelete, bool $recordWasDeleted, DataHandler $dataHandler)
+    {
+        if ($table !== self::TABLE) {
+            return;
+        }
+        $this->addVisitorEmailsOfPeriod($id);
+    }
+
+    public function addVisitorEmailsOfPeriod(int $periodUid)
+    {
+        /** @var QueryBuilder $queryBuilder */
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable(self::TABLE);
+        $rows = $queryBuilder
+            ->select('o.email', 'o.pid', 'f.from_name', 'f.from_email', 'f.reply_to_name', 'f.reply_to_email')
+            ->from(self::TABLE, 'p')
+            ->leftJoin('p', 'tx_reserve_domain_model_order', 'o', 'o.booked_period = p.uid')
+            ->leftJoin('p', 'tx_reserve_domain_model_facility', 'f', 'f.uid = p.facility')
+            ->where(
+                $queryBuilder->expr()->andX(
+                    $queryBuilder->expr()->eq('p.uid', $queryBuilder->createNamedParameter($periodUid)),
+                    $queryBuilder->expr()->neq('o.order_type', $queryBuilder->createNamedParameter(Order::TYPE_ARCHIVED))
+                )
+            )
+            ->execute()
+            ->fetchAll();
+        $this->visitorEmails[$periodUid] = [];
+        foreach ($rows as $row) {
+            $this->visitorEmails[$periodUid][] = $row['email'];
+        }
+        if (!empty($rows)) {
+            $this->pid = $rows[0]['pid'];
+            // this won't work if one deletes multiple periods of multiple facilities using the multi-selection mode
+            $this->fromName = $rows[0]['from_name'];
+            $this->fromEmail = $rows[0]['from_email'];
+            $this->replyToName = $rows[0]['reply_to_name'];
+            $this->replyToEmail = $rows[0]['reply_to_email'];
+        }
+    }
+
+    public function processDataHandlerCmdResultAfterFinish(DataHandler $dataHandler)
+    {
+        if (!empty($this->visitorEmails)) {
+            foreach (array_keys($this->visitorEmails) as $periodUid) {
+                if (!$dataHandler->hasDeletedRecord(self::TABLE, $periodUid)) {
+                    // maybe the record was not removed but intended for removal and added to this array
+                    unset($this->visitorEmails[$periodUid]);
+                }
+            }
+            if (!empty($this->visitorEmails)) {
+                $this->addJavaScriptAndSettingsToPageRenderer();
+            }
+        }
+    }
+
+    protected function addJavaScriptAndSettingsToPageRenderer()
+    {
+        $params = [
+            'edit' => ['tx_reserve_domain_model_email' => [$this->pid => 'new']],
+            'returnUrl' => '#txReserveCloseModal',
+            'defVals' => [
+                'tx_reserve_domain_model_email' => [
+                    'body' => LocalizationUtility::translate('email.body.afterPeriodDeletion', 'reserve'),
+                    'receiver_type' => Email::RECEIVER_TYPE_MANUAL,
+                    'from_name' => $this->fromName,
+                    'from_email' => $this->fromEmail,
+                    'reply_to_name' => $this->replyToName,
+                    'reply_to_email' => $this->replyToEmail,
+                    'custom_receivers' => implode(',', array_map(function($a) {return implode(',', $a);}, $this->visitorEmails)),
+                ]
+            ],
+            'noView' => true,
+
+        ];
+        $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+        // Add configuration to tx_reserve_modal in user session. This will be checked inside the PageRenderer hook
+        // Class: JWeiland\Reserve\Hooks\PageRenderer->processTxReserveModalUserSetting()
+        $this->getBackendUserAuthentication()->setAndSaveSessionData(
+            PageRenderer::MODAL_SESSION_KEY,
+            [
+                'jsInlineCode' => [
+                    'Require-JS-Module-TYPO3/CMS/Reserve/Backend/AskForMailAfterEditModule' => 'require(["TYPO3/CMS/Reserve/Backend/AskForMailAfterEditModule"]);'
+                ],
+                'inlineSettings' => [
+                    'reserve.showModal' => [
+                        'title' => LocalizationUtility::translate('modal.periodAskForMailAfterDeletion.title', 'reserve'),
+                        'message' => LocalizationUtility::translate('modal.periodAskForMailAfterDeletion.message', 'reserve'),
+                        'uri' => (string)$uriBuilder->buildUriFromRoute('record_edit', $params)
+                    ]
+                ],
+                'inlineLanguageLabel' => [
+                    'reserve.modal.button.writeMail' => LocalizationUtility::translate('modal.button.writeMail', 'reserve')
+                ]
+            ]
+        );
+    }
+
+    protected function getBackendUserAuthentication(): BackendUserAuthentication
+    {
+        return $GLOBALS['BE_USER'];
+    }
+}

--- a/Classes/DataHandler/AskForMailAfterPeriodUpdate.php
+++ b/Classes/DataHandler/AskForMailAfterPeriodUpdate.php
@@ -102,7 +102,7 @@ class AskForMailAfterPeriodUpdate
             'returnUrl' => '#txReserveCloseModal',
             'defVals' => [
                 'tx_reserve_domain_model_email' => [
-                    'subject' => 'Test',
+                    'body' => LocalizationUtility::translate('email.body.afterPeriodUpdate', 'reserve'),
                     'periods' => implode(',', $this->updatedRecords)
                 ]
             ],
@@ -126,7 +126,7 @@ class AskForMailAfterPeriodUpdate
                     ]
                 ],
                 'inlineLanguageLabel' => [
-                    'reserve.modal.periodAskForMail.button.writeMail' => LocalizationUtility::translate('modal.periodAskForMail.button.writeMail', 'reserve')
+                    'reserve.modal.button.writeMail' => LocalizationUtility::translate('modal.button.writeMail', 'reserve')
                 ]
             ]
         );

--- a/Classes/DataHandler/AskForMailAfterPeriodUpdate.php
+++ b/Classes/DataHandler/AskForMailAfterPeriodUpdate.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\DataHandler;

--- a/Classes/DataHandler/AskForMailAfterPeriodUpdate.php
+++ b/Classes/DataHandler/AskForMailAfterPeriodUpdate.php
@@ -15,19 +15,20 @@ declare(strict_types=1);
  * The TYPO3 project - inspiring people to share!
  */
 
-namespace JWeiland\Reserve\Service;
+namespace JWeiland\Reserve\DataHandler;
 
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
  * Service to process the result of the DataHandler hook processDatamap_afterAllOperations
  * to notify the user about changes of periods and ask them to send a mail to the visitors.
  */
-class AskForMailService
+class AskForMailAfterPeriodUpdate
 {
     const TABLE = 'tx_reserve_domain_model_period';
 
@@ -94,17 +95,23 @@ class AskForMailService
 
         $params = [
             'edit' => ['tx_reserve_domain_model_email' => [$row['pid'] => 'new']],
-            'returnUrl' => '',
-            'defVals' => ['tx_reserve_domain_model_email' => ['subject' => 'Test', 'periods' => implode(',', $this->updatedRecords)]]
+            'returnUrl' => '#txReserveCloseModal',
+            'defVals' => ['tx_reserve_domain_model_email' => ['subject' => 'Test', 'periods' => implode(',', $this->updatedRecords)]],
+            'noView' => true,
+
         ];
         $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
         $pageRenderer->addInlineSettingArray(
-            'reserve.modals',
-            [[
-                'title' => 'Replace by title ;)',
-                'message' => 'The time of at least one period has changed! Do you want to compose a mail to the affected visitors?',
+            'reserve.showModal',
+            [
+                'title' => LocalizationUtility::translate('modal.periodAskForMail.title', 'reserve'),
+                'message' => LocalizationUtility::translate('modal.periodAskForMail.message', 'reserve'),
                 'uri' => (string)$uriBuilder->buildUriFromRoute('record_edit', $params)
-            ]]
+            ]
+        );
+        $pageRenderer->addInlineLanguageLabel(
+            'reserve.modal.periodAskForMail.button.writeMail',
+            LocalizationUtility::translate('modal.periodAskForMail.button.writeMail', 'reserve')
         );
     }
 }

--- a/Classes/DataHandler/AskForMailAfterPeriodUpdate.php
+++ b/Classes/DataHandler/AskForMailAfterPeriodUpdate.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace JWeiland\Reserve\DataHandler;
 
+use JWeiland\Reserve\Hooks\PageRenderer;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -109,24 +110,26 @@ class AskForMailAfterPeriodUpdate
 
         ];
         $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
-        // Add configuration to tx_reserve_modal. This will be checked inside the PageRenderer hook
+        // Add configuration to tx_reserve_modal in user session. This will be checked inside the PageRenderer hook
         // Class: JWeiland\Reserve\Hooks\PageRenderer->processTxReserveModalUserSetting()
-        $this->getBackendUserAuthentication()->uc[\JWeiland\Reserve\Hooks\PageRenderer::MODAL_UC_KEY] = [
-            'jsInlineCode' => [
-                'Require-JS-Module-TYPO3/CMS/Reserve/Backend/AskForMailAfterEditModule' => 'require(["TYPO3/CMS/Reserve/Backend/AskForMailAfterEditModule"]);'
-            ],
-            'inlineSettings' => [
-                'reserve.showModal' => [
-                    'title' => LocalizationUtility::translate('modal.periodAskForMail.title', 'reserve'),
-                    'message' => LocalizationUtility::translate('modal.periodAskForMail.message', 'reserve'),
-                    'uri' => (string)$uriBuilder->buildUriFromRoute('record_edit', $params)
+        $this->getBackendUserAuthentication()->setAndSaveSessionData(
+            PageRenderer::MODAL_SESSION_KEY,
+            [
+                'jsInlineCode' => [
+                    'Require-JS-Module-TYPO3/CMS/Reserve/Backend/AskForMailAfterEditModule' => 'require(["TYPO3/CMS/Reserve/Backend/AskForMailAfterEditModule"]);'
+                ],
+                'inlineSettings' => [
+                    'reserve.showModal' => [
+                        'title' => LocalizationUtility::translate('modal.periodAskForMail.title', 'reserve'),
+                        'message' => LocalizationUtility::translate('modal.periodAskForMail.message', 'reserve'),
+                        'uri' => (string)$uriBuilder->buildUriFromRoute('record_edit', $params)
+                    ]
+                ],
+                'inlineLanguageLabel' => [
+                    'reserve.modal.periodAskForMail.button.writeMail' => LocalizationUtility::translate('modal.periodAskForMail.button.writeMail', 'reserve')
                 ]
-            ],
-            'inlineLanguageLabel' => [
-                'reserve.modal.periodAskForMail.button.writeMail' => LocalizationUtility::translate('modal.periodAskForMail.button.writeMail', 'reserve')
             ]
-        ];
-        $this->getBackendUserAuthentication()->writeUC();
+        );
     }
 
     protected function getBackendUserAuthentication(): BackendUserAuthentication

--- a/Classes/DataHandler/AskForMailAfterPeriodUpdate.php
+++ b/Classes/DataHandler/AskForMailAfterPeriodUpdate.php
@@ -59,9 +59,19 @@ class AskForMailAfterPeriodUpdate
 
     protected function checkForUpdatedRecords()
     {
+        if (!array_key_exists(self::TABLE, $this->dataHandler->datamap)) {
+            return;
+        }
+        // This looks very dangerous but it's safe because we just use this to read
+        // the historyRecords after all operations. In TYPO3 v10 $dataHandler->getHistoryRecords()
+        // has been added, so replace this reflection when this extension requires TYPO3 >= v10
+        $dataHandlerReflection = new \ReflectionClass($this->dataHandler);
+        $historyRecordsProperty = $dataHandlerReflection->getProperty('historyRecords');
+        $historyRecordsProperty->setAccessible(true);
+
         $checkFields = ['begin', 'end', 'date'];
         $updatedRecords = [];
-        foreach ($this->dataHandler->getHistoryRecords() as $recordId => $historyRecord) {
+        foreach ($historyRecordsProperty->getValue($this->dataHandler) as $recordId => $historyRecord) {
             if (strpos($recordId, self::TABLE) === false) {
                 continue;
             }

--- a/Classes/DataHandler/FacilityClearCacheAfterUpdate.php
+++ b/Classes/DataHandler/FacilityClearCacheAfterUpdate.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace JWeiland\Reserve\DataHandler;
+
+use Doctrine\DBAL\Connection;
+use JWeiland\Reserve\Utility\CacheUtility;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Messaging\FlashMessageQueue;
+use TYPO3\CMS\Core\Messaging\FlashMessageService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+
+/**
+ * Service to process the result of the DataHandler hook processDatamap_afterAllOperations
+ * to check if caches of frontend facility list view needs to be cleared
+ */
+class FacilityClearCacheAfterUpdate
+{
+    /**
+     * @var DataHandler
+     */
+    protected $dataHandler;
+
+    public function processDataHandlerResultAfterAllOperations(DataHandler $dataHandler): bool
+    {
+        $this->dataHandler = $dataHandler;
+        $facilityNames = [];
+        // maybe split this big condition block into separated methods
+        if (array_key_exists('tx_reserve_domain_model_facility', $dataHandler->datamap)) {
+            foreach ($dataHandler->datamap['tx_reserve_domain_model_facility'] as $uid => $row) {
+                CacheUtility::clearPageCachesForPagesWithCurrentFacility($uid);
+                $facilityNames[] = $row['name'];
+            }
+        } elseif (array_key_exists('tx_reserve_domain_model_order', $dataHandler->datamap)) {
+            /** @var QueryBuilder $queryBuilder */
+            $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_reserve_domain_model_order');
+            $queryBuilder
+                ->select('f.uid', 'f.name')
+                ->from('tx_reserve_domain_model_order', 'o')
+                ->leftJoin('o', 'tx_reserve_domain_model_period', 'p', 'o.booked_period = p.uid')
+                ->leftJoin('p', 'tx_reserve_domain_model_facility', 'f', 'p.facility = f.uid')
+                ->where($queryBuilder->expr()->in('o.uid', $queryBuilder->createNamedParameter(
+                    $this->replaceNewWithIds(array_keys($dataHandler->datamap['tx_reserve_domain_model_order'])),
+                    Connection::PARAM_INT_ARRAY
+                )))
+                ->groupBy('f.uid');
+            foreach ($queryBuilder->execute()->fetchAll() as $row) {
+                CacheUtility::clearPageCachesForPagesWithCurrentFacility((int)$row['uid']);
+                $facilityNames[] = $row['name'];
+            }
+        } elseif (array_key_exists('tx_reserve_domain_model_period', $dataHandler->datamap)) {
+            /** @var QueryBuilder $queryBuilder */
+            $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_reserve_domain_model_order');
+            $queryBuilder
+                ->select('f.uid', 'f.name')
+                ->from('tx_reserve_domain_model_period', 'p')
+                ->leftJoin('p', 'tx_reserve_domain_model_facility', 'f', 'p.facility = f.uid')
+                ->where($queryBuilder->expr()->in('p.uid', $queryBuilder->createNamedParameter(
+                    $this->replaceNewWithIds(array_keys($dataHandler->datamap['tx_reserve_domain_model_period'])),
+                    Connection::PARAM_INT_ARRAY
+                )))
+                ->groupBy('f.uid');
+            foreach ($queryBuilder->execute()->fetchAll() as $row) {
+                CacheUtility::clearPageCachesForPagesWithCurrentFacility((int)$row['uid']);
+                $facilityNames[] = $row['name'];
+            }
+        } elseif (array_key_exists('tx_reserve_domain_model_reservation', $dataHandler->datamap)) {
+            /** @var QueryBuilder $queryBuilder */
+            $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_reserve_domain_model_order');
+            $queryBuilder
+                ->select('f.uid', 'f.name')
+                ->from('tx_reserve_domain_model_reservation', 'r')
+                ->leftJoin('r', 'tx_reserve_domain_model_order', 'o', 'r.customer_order = o.uid')
+                ->leftJoin('o', 'tx_reserve_domain_model_period', 'p', 'o.booked_period = p.uid')
+                ->leftJoin('p', 'tx_reserve_domain_model_facility', 'f', 'p.facility = f.uid')
+                ->where($queryBuilder->expr()->in('r.uid', $queryBuilder->createNamedParameter(
+                    $this->replaceNewWithIds(array_keys($dataHandler->datamap['tx_reserve_domain_model_reservation'])),
+                    Connection::PARAM_INT_ARRAY
+                )))
+                ->groupBy('f.uid');
+            foreach ($queryBuilder->execute()->fetchAll() as $row) {
+                CacheUtility::clearPageCachesForPagesWithCurrentFacility((int)$row['uid']);
+                $facilityNames[] = $row['name'];
+            }
+        }
+        if (!empty($facilityNames)) {
+            /** @var FlashMessageQueue $flashMessageQueue */
+            $flashMessageQueue = GeneralUtility::makeInstance(FlashMessageService::class)->getMessageQueueByIdentifier();
+            /** @var FlashMessage $flashMessage */
+            $flashMessage = GeneralUtility::makeInstance(FlashMessage::class,
+                LocalizationUtility::translate('flashMessage.clearedCacheForFacility', 'reserve', [implode(', ', $facilityNames)]), '', FlashMessage::INFO);
+            $flashMessageQueue->addMessage($flashMessage);
+            return true;
+        }
+        return false;
+    }
+
+    protected function replaceNewWithIds(array $ids): array
+    {
+        foreach ($ids as &$id) {
+            if (is_string($id) && strpos($id, 'NEW') === 0) {
+                $id = $this->dataHandler->substNEWwithIDs[$id];
+            }
+        }
+        return $ids;
+    }
+}

--- a/Classes/Domain/Model/Email.php
+++ b/Classes/Domain/Model/Email.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace JWeiland\Reserve\Domain\Model;
+
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+
+class Email extends AbstractEntity
+{
+    /**
+     * @var string
+     */
+    protected $subject = '';
+
+    /**
+     * @var string
+     */
+    protected $body = '';
+
+    /**
+     * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\JWeiland\Reserve\Domain\Model\Period>
+     */
+    protected $periods;
+
+    /**
+     * @var bool
+     */
+    protected $locked = false;
+
+    /**
+     * @var string serialized json!
+     * @internal
+     */
+    protected $commandData = '';
+
+    /**
+     * @var array unserialized object
+     * @internal
+     */
+    protected $commandDataUnserialized = [];
+
+    public function __construct()
+    {
+        $this->periods = new ObjectStorage();
+    }
+
+    /**
+     * @return string
+     */
+    public function getSubject(): string
+    {
+        return $this->subject;
+    }
+
+    /**
+     * @param string $subject
+     */
+    public function setSubject(string $subject)
+    {
+        $this->subject = $subject;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBody(): string
+    {
+        return $this->body;
+    }
+
+    /**
+     * @param string $body
+     */
+    public function setBody(string $body)
+    {
+        $this->body = $body;
+    }
+
+    /**
+     * @return ObjectStorage|Period[]
+     */
+    public function getPeriods(): ObjectStorage
+    {
+        return $this->periods;
+    }
+
+    /**
+     * @param ObjectStorage $periods
+     */
+    public function setPeriods(ObjectStorage $periods)
+    {
+        $this->periods = $periods;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isLocked(): bool
+    {
+        return $this->locked;
+    }
+
+    /**
+     * @param bool $locked
+     */
+    public function setLocked(bool $locked)
+    {
+        $this->locked = $locked;
+    }
+
+    /**
+     * @return array
+     * @internal
+     */
+    public function getCommandData(): array
+    {
+        if (!$this->commandDataUnserialized) {
+            $this->commandDataUnserialized = (array)unserialize($this->commandData, ['allowed_classes' => false]);
+        }
+        return $this->commandDataUnserialized;
+    }
+
+    /**
+     * @param array $commandData
+     * @internal
+     */
+    public function setCommandData(array $commandData)
+    {
+        $this->commandData = serialize($commandData);
+        $this->commandDataUnserialized = [];
+    }
+}

--- a/Classes/Domain/Model/Email.php
+++ b/Classes/Domain/Model/Email.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Domain\Model;

--- a/Classes/Domain/Model/Facility.php
+++ b/Classes/Domain/Model/Facility.php
@@ -3,16 +3,10 @@
 declare(strict_types = 1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Domain\Model;

--- a/Classes/Domain/Model/Order.php
+++ b/Classes/Domain/Model/Order.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Domain\Model;

--- a/Classes/Domain/Model/Period.php
+++ b/Classes/Domain/Model/Period.php
@@ -205,7 +205,7 @@ class Period extends AbstractEntity
     }
 
     /**
-     * @return ObjectStorage
+     * @return ObjectStorage|Order[]
      */
     public function getOrders(): ObjectStorage
     {

--- a/Classes/Domain/Model/Period.php
+++ b/Classes/Domain/Model/Period.php
@@ -3,16 +3,10 @@
 declare(strict_types = 1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Domain\Model;

--- a/Classes/Domain/Model/Reservation.php
+++ b/Classes/Domain/Model/Reservation.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Domain\Model;

--- a/Classes/Domain/Model/v8/Facility.php
+++ b/Classes/Domain/Model/v8/Facility.php
@@ -3,16 +3,10 @@
 declare(strict_types = 1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Domain\Model\v8;

--- a/Classes/Domain/Model/v8/Order.php
+++ b/Classes/Domain/Model/v8/Order.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Domain\Model\v8;

--- a/Classes/Domain/Model/v8/Period.php
+++ b/Classes/Domain/Model/v8/Period.php
@@ -3,16 +3,10 @@
 declare(strict_types = 1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Domain\Model\v8;

--- a/Classes/Domain/Repository/EmailRepository.php
+++ b/Classes/Domain/Repository/EmailRepository.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Domain\Repository;
@@ -26,9 +20,6 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 class EmailRepository extends Repository
 {
-    /**
-     * @return QueryResultInterface
-     */
     public function findAll(): QueryResultInterface
     {
         $query = $this->createQuery();

--- a/Classes/Domain/Repository/EmailRepository.php
+++ b/Classes/Domain/Repository/EmailRepository.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace JWeiland\Reserve\Domain\Repository;
+
+use JWeiland\Reserve\Domain\Model\Email;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
+use TYPO3\CMS\Extbase\Persistence\Repository;
+
+class EmailRepository extends Repository
+{
+    /**
+     * @return QueryResultInterface
+     */
+    public function findAll(): QueryResultInterface
+    {
+        $query = $this->createQuery();
+        $query->getQuerySettings()->setRespectStoragePage(false);
+        return $query->execute();
+    }
+
+    /**
+     * @return Email|null
+     */
+    public function findOneUnlocked()
+    {
+        $query = $this->createQuery();
+        $query->getQuerySettings()->setRespectStoragePage(false);
+        $query->matching($query->equals('locked', false));
+        return $query->execute()->getFirst();
+    }
+
+    public function lockEmail(int $uid)
+    {
+        /** @var Connection $connection */
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('tx_reserve_domain_model_email');
+        $connection->update('tx_reserve_domain_model_email', ['locked' => true], ['uid' => $uid]);
+    }
+
+    public function unlockEmail(int $uid)
+    {
+        /** @var Connection $connection */
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('tx_reserve_domain_model_email');
+        $connection->update('tx_reserve_domain_model_email', ['locked' => false], ['uid' => $uid]);
+    }
+}

--- a/Classes/Domain/Repository/EmailRepository.php
+++ b/Classes/Domain/Repository/EmailRepository.php
@@ -47,17 +47,17 @@ class EmailRepository extends Repository
         return $query->execute()->getFirst();
     }
 
-    public function lockEmail(int $uid)
+    /**
+     * @param int $uid
+     * @param Email|null $email optional to set "locked" property in ExtBase domain model
+     */
+    public function lockEmail(int $uid, Email $email = null)
     {
         /** @var Connection $connection */
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('tx_reserve_domain_model_email');
         $connection->update('tx_reserve_domain_model_email', ['locked' => true], ['uid' => $uid]);
-    }
-
-    public function unlockEmail(int $uid)
-    {
-        /** @var Connection $connection */
-        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('tx_reserve_domain_model_email');
-        $connection->update('tx_reserve_domain_model_email', ['locked' => false], ['uid' => $uid]);
+        if ($email) {
+            $email->setLocked(true);
+        }
     }
 }

--- a/Classes/Domain/Repository/FacilityRepository.php
+++ b/Classes/Domain/Repository/FacilityRepository.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Domain\Repository;

--- a/Classes/Domain/Repository/OrderRepository.php
+++ b/Classes/Domain/Repository/OrderRepository.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Domain\Repository;

--- a/Classes/Domain/Repository/PeriodRepository.php
+++ b/Classes/Domain/Repository/PeriodRepository.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Domain\Repository;

--- a/Classes/Domain/Repository/ReservationRepository.php
+++ b/Classes/Domain/Repository/ReservationRepository.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Domain\Repository;

--- a/Classes/Domain/Validation/OrderValidator.php
+++ b/Classes/Domain/Validation/OrderValidator.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Domain\Validation;

--- a/Classes/Form/Element/QrCodePreviewElement.php
+++ b/Classes/Form/Element/QrCodePreviewElement.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Form\Element;

--- a/Classes/Form/Resolver/CheckboxToggleElementResolver.php
+++ b/Classes/Form/Resolver/CheckboxToggleElementResolver.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace JWeiland\Reserve\Form\Resolver;
 
+use TYPO3\CMS\Backend\Form\Element\CheckboxElement;
 use TYPO3\CMS\Backend\Form\Element\CheckboxToggleElement;
 use TYPO3\CMS\Backend\Form\NodeFactory;
 use TYPO3\CMS\Backend\Form\NodeResolverInterface;
@@ -30,6 +31,6 @@ class CheckboxToggleElementResolver implements NodeResolverInterface
         if (class_exists(\TYPO3\CMS\Backend\Form\Element\CheckboxToggleElement::class)) {
             return CheckboxToggleElement::class;
         }
-        return null;
+        return CheckboxElement::class;
     }
 }

--- a/Classes/Form/Resolver/CheckboxToggleElementResolver.php
+++ b/Classes/Form/Resolver/CheckboxToggleElementResolver.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package jweiland/reserve.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace JWeiland\Reserve\Form\Resolver;
+
+use TYPO3\CMS\Backend\Form\Element\CheckboxToggleElement;
+use TYPO3\CMS\Backend\Form\NodeFactory;
+use TYPO3\CMS\Backend\Form\NodeResolverInterface;
+
+class CheckboxToggleElementResolver implements NodeResolverInterface
+{
+    protected $data;
+
+    public function __construct(NodeFactory $nodeFactory, array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function resolve()
+    {
+        $parameterArray = $this->data['parameterArray'];
+        if (class_exists(\TYPO3\CMS\Backend\Form\Element\CheckboxToggleElement::class)) {
+            return CheckboxToggleElement::class;
+        }
+        return null;
+    }
+}

--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -17,99 +17,15 @@ declare(strict_types=1);
 
 namespace JWeiland\Reserve\Hooks;
 
-use Doctrine\DBAL\Connection;
-use JWeiland\Reserve\Service\AskForMailService;
-use JWeiland\Reserve\Utility\CacheUtility;
-use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Database\Query\QueryBuilder;
-use TYPO3\CMS\Core\Messaging\FlashMessage;
-use TYPO3\CMS\Core\Messaging\FlashMessageQueue;
-use TYPO3\CMS\Core\Messaging\FlashMessageService;
+use JWeiland\Reserve\DataHandler\AskForMailAfterPeriodUpdate;
+use JWeiland\Reserve\DataHandler\FacilityClearCacheAfterUpdate;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 class DataHandler
 {
     public function processDatamap_afterAllOperations(\TYPO3\CMS\Core\DataHandling\DataHandler $dataHandler)
     {
-        GeneralUtility::makeInstance(AskForMailService::class)->processDataHandlerResultAfterAllOperations($dataHandler);
-
-        // TODO: Create own method or class for that cache conditions!
-        $facilityNames = [];
-        if (array_key_exists('tx_reserve_domain_model_facility', $dataHandler->datamap)) {
-            foreach ($dataHandler->datamap['tx_reserve_domain_model_facility'] as $uid => $row) {
-                CacheUtility::clearPageCachesForPagesWithCurrentFacility($uid);
-                $facilityNames[] = $row['name'];
-            }
-        } elseif (array_key_exists('tx_reserve_domain_model_order', $dataHandler->datamap)) {
-            /** @var QueryBuilder $queryBuilder */
-            $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_reserve_domain_model_order');
-            $queryBuilder
-                ->select('f.uid', 'f.name')
-                ->from('tx_reserve_domain_model_order', 'o')
-                ->leftJoin('o', 'tx_reserve_domain_model_period', 'p', 'o.booked_period = p.uid')
-                ->leftJoin('p', 'tx_reserve_domain_model_facility', 'f', 'p.facility = f.uid')
-                ->where($queryBuilder->expr()->in('o.uid', $queryBuilder->createNamedParameter(
-                    $this->replaceNewWithIds(array_keys($dataHandler->datamap['tx_reserve_domain_model_order']), $dataHandler),
-                    Connection::PARAM_INT_ARRAY
-                )))
-                ->groupBy('f.uid');
-            foreach ($queryBuilder->execute()->fetchAll() as $row) {
-                CacheUtility::clearPageCachesForPagesWithCurrentFacility((int)$row['uid']);
-                $facilityNames[] = $row['name'];
-            }
-        } elseif (array_key_exists('tx_reserve_domain_model_period', $dataHandler->datamap)) {
-            /** @var QueryBuilder $queryBuilder */
-            $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_reserve_domain_model_order');
-            $queryBuilder
-                ->select('f.uid', 'f.name')
-                ->from('tx_reserve_domain_model_period', 'p')
-                ->leftJoin('p', 'tx_reserve_domain_model_facility', 'f', 'p.facility = f.uid')
-                ->where($queryBuilder->expr()->in('p.uid', $queryBuilder->createNamedParameter(
-                    $this->replaceNewWithIds(array_keys($dataHandler->datamap['tx_reserve_domain_model_period']), $dataHandler),
-                    Connection::PARAM_INT_ARRAY
-                )))
-                ->groupBy('f.uid');
-            foreach ($queryBuilder->execute()->fetchAll() as $row) {
-                CacheUtility::clearPageCachesForPagesWithCurrentFacility((int)$row['uid']);
-                $facilityNames[] = $row['name'];
-            }
-        } elseif (array_key_exists('tx_reserve_domain_model_reservation', $dataHandler->datamap)) {
-            /** @var QueryBuilder $queryBuilder */
-            $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_reserve_domain_model_order');
-            $queryBuilder
-                ->select('f.uid', 'f.name')
-                ->from('tx_reserve_domain_model_reservation', 'r')
-                ->leftJoin('r', 'tx_reserve_domain_model_order', 'o', 'r.customer_order = o.uid')
-                ->leftJoin('o', 'tx_reserve_domain_model_period', 'p', 'o.booked_period = p.uid')
-                ->leftJoin('p', 'tx_reserve_domain_model_facility', 'f', 'p.facility = f.uid')
-                ->where($queryBuilder->expr()->in('r.uid', $queryBuilder->createNamedParameter(
-                    $this->replaceNewWithIds(array_keys($dataHandler->datamap['tx_reserve_domain_model_reservation']), $dataHandler),
-                    Connection::PARAM_INT_ARRAY
-                )))
-                ->groupBy('f.uid');
-            foreach ($queryBuilder->execute()->fetchAll() as $row) {
-                CacheUtility::clearPageCachesForPagesWithCurrentFacility((int)$row['uid']);
-                $facilityNames[] = $row['name'];
-            }
-        }
-        if (!empty($facilityNames)) {
-            /** @var FlashMessageQueue $flashMessageQueue */
-            $flashMessageQueue = GeneralUtility::makeInstance(FlashMessageService::class)->getMessageQueueByIdentifier();
-            /** @var FlashMessage $flashMessage */
-            $flashMessage = GeneralUtility::makeInstance(FlashMessage::class,
-                LocalizationUtility::translate('flashMessage.clearedCacheForFacility', 'reserve', [implode(', ', $facilityNames)]), '', FlashMessage::INFO);
-            $flashMessageQueue->addMessage($flashMessage);
-        }
-    }
-
-    protected function replaceNewWithIds(array $ids, \TYPO3\CMS\Core\DataHandling\DataHandler $dataHandler): array
-    {
-        foreach ($ids as &$id) {
-            if (is_string($id) && strpos($id, 'NEW') === 0) {
-                $id = $dataHandler->substNEWwithIDs[$id];
-            }
-        }
-        return $ids;
+        GeneralUtility::makeInstance(AskForMailAfterPeriodUpdate::class)->processDataHandlerResultAfterAllOperations($dataHandler);
+        GeneralUtility::makeInstance(FacilityClearCacheAfterUpdate::class)->processDataHandlerResultAfterAllOperations($dataHandler);
     }
 }

--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace JWeiland\Reserve\Hooks;
 
+use JWeiland\Reserve\DataHandler\AskForMailAfterPeriodDeletion;
 use JWeiland\Reserve\DataHandler\AskForMailAfterPeriodUpdate;
 use JWeiland\Reserve\DataHandler\FacilityClearCacheAfterUpdate;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -27,5 +28,15 @@ class DataHandler
     {
         GeneralUtility::makeInstance(AskForMailAfterPeriodUpdate::class)->processDataHandlerResultAfterAllOperations($dataHandler);
         GeneralUtility::makeInstance(FacilityClearCacheAfterUpdate::class)->processDataHandlerResultAfterAllOperations($dataHandler);
+    }
+
+    public function processCmdmap_deleteAction(string $table, int $id, array $recordToDelete, bool $recordWasDeleted, \TYPO3\CMS\Core\DataHandling\DataHandler $dataHandler)
+    {
+        GeneralUtility::makeInstance(AskForMailAfterPeriodDeletion::class)->processDataHandlerCmdDeleteAction($table, $id, $recordToDelete, $recordWasDeleted, $dataHandler);
+    }
+
+    public function processCmdmap_afterFinish(\TYPO3\CMS\Core\DataHandling\DataHandler $dataHandler)
+    {
+        GeneralUtility::makeInstance(AskForMailAfterPeriodDeletion::class)->processDataHandlerCmdResultAfterFinish($dataHandler);
     }
 }

--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Hooks;

--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace JWeiland\Reserve\Hooks;
 
 use Doctrine\DBAL\Connection;
+use JWeiland\Reserve\Service\AskForMailService;
 use JWeiland\Reserve\Utility\CacheUtility;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -31,6 +32,9 @@ class DataHandler
 {
     public function processDatamap_afterAllOperations(\TYPO3\CMS\Core\DataHandling\DataHandler $dataHandler)
     {
+        GeneralUtility::makeInstance(AskForMailService::class)->processDataHandlerResultAfterAllOperations($dataHandler);
+
+        // TODO: Create own method or class for that cache conditions!
         $facilityNames = [];
         if (array_key_exists('tx_reserve_domain_model_facility', $dataHandler->datamap)) {
             foreach ($dataHandler->datamap['tx_reserve_domain_model_facility'] as $uid => $row) {

--- a/Classes/Hooks/PageRenderer.php
+++ b/Classes/Hooks/PageRenderer.php
@@ -22,7 +22,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class PageRenderer
 {
-    const MODAL_UC_KEY = 'tx_reserve_modal';
+    const MODAL_SESSION_KEY = 'tx_reserve_modal';
 
     /**
      * Check the setting tx_reserve_modal (self::MODAL_UC_KEY) and add all necessary data
@@ -36,9 +36,8 @@ class PageRenderer
     {
         if (
             TYPO3_MODE === 'BE'
-            && $this->getBackendUserAuthentication()->uc
-            && array_key_exists('tx_reserve_modal', $this->getBackendUserAuthentication()->uc)
-            && !empty($this->getBackendUserAuthentication()->uc[self::MODAL_UC_KEY])
+            && $this->getBackendUserAuthentication()->user
+            && $configuration = $this->getBackendUserAuthentication()->getSessionData(self::MODAL_SESSION_KEY)
         ) {
             /** @var \TYPO3\CMS\Core\Page\PageRenderer $pageRenderer */
             $pageRenderer = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
@@ -47,7 +46,6 @@ class PageRenderer
                 'require(["TYPO3/CMS/Reserve/Backend/AskForMailAfterEditModule"]);'
             );
 
-            $configuration = $this->getBackendUserAuthentication()->uc[self::MODAL_UC_KEY];
             foreach ($configuration['jsInlineCode'] as $name => $block) {
                 $pageRenderer->addJsInlineCode($name, $block);
             }
@@ -59,8 +57,7 @@ class PageRenderer
             }
 
             // remove modal configuration of current modal
-            unset($this->getBackendUserAuthentication()->uc[self::MODAL_UC_KEY]);
-            $this->getBackendUserAuthentication()->writeUC();
+            $this->getBackendUserAuthentication()->setAndSaveSessionData(self::MODAL_SESSION_KEY, null);
         }
     }
 

--- a/Classes/Hooks/PageRenderer.php
+++ b/Classes/Hooks/PageRenderer.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace JWeiland\Reserve\Hooks;
+
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class PageRenderer
+{
+    const MODAL_UC_KEY = 'tx_reserve_modal';
+
+    /**
+     * Check the setting tx_reserve_modal (self::MODAL_UC_KEY) and add all necessary data
+     * using the information from current BE_USER. Then remove the configuration when the
+     * current settings are processed.
+     *
+     * @param array $params
+     * @param \TYPO3\CMS\Core\Page\PageRenderer $pageRenderer
+     */
+    public function processTxReserveModalUserSetting(array $params, \TYPO3\CMS\Core\Page\PageRenderer $pageRenderer)
+    {
+        if (
+            TYPO3_MODE === 'BE'
+            && array_key_exists('tx_reserve_modal', $this->getBackendUserAuthentication()->uc)
+            && !empty($this->getBackendUserAuthentication()->uc[self::MODAL_UC_KEY])
+        ) {
+            /** @var \TYPO3\CMS\Core\Page\PageRenderer $pageRenderer */
+            $pageRenderer = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
+            $pageRenderer->addJsInlineCode(
+                'Require-JS-Module-TYPO3/CMS/Reserve/Backend/AskForMailAfterEditModule',
+                'require(["TYPO3/CMS/Reserve/Backend/AskForMailAfterEditModule"]);'
+            );
+
+            $configuration = $this->getBackendUserAuthentication()->uc[self::MODAL_UC_KEY];
+            foreach ($configuration['jsInlineCode'] as $name => $block) {
+                $pageRenderer->addJsInlineCode($name, $block);
+            }
+            foreach ($configuration['inlineSettings'] as $namespace => $array){
+                $pageRenderer->addInlineSettingArray($namespace, $array);
+            }
+            foreach ($configuration['inlineLanguageLabel'] as $namespace => $value) {
+                $pageRenderer->addInlineLanguageLabel($namespace, $value);
+            }
+
+            // remove modal configuration of current modal
+            unset($this->getBackendUserAuthentication()->uc[self::MODAL_UC_KEY]);
+            $this->getBackendUserAuthentication()->writeUC();
+        }
+    }
+
+    protected function getBackendUserAuthentication(): BackendUserAuthentication
+    {
+        return $GLOBALS['BE_USER'];
+    }
+}

--- a/Classes/Hooks/PageRenderer.php
+++ b/Classes/Hooks/PageRenderer.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Hooks;

--- a/Classes/Hooks/PageRenderer.php
+++ b/Classes/Hooks/PageRenderer.php
@@ -36,6 +36,7 @@ class PageRenderer
     {
         if (
             TYPO3_MODE === 'BE'
+            && $this->getBackendUserAuthentication()->uc
             && array_key_exists('tx_reserve_modal', $this->getBackendUserAuthentication()->uc)
             && !empty($this->getBackendUserAuthentication()->uc[self::MODAL_UC_KEY])
         ) {

--- a/Classes/Service/AskForMailService.php
+++ b/Classes/Service/AskForMailService.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace JWeiland\Reserve\Service;
+
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Service to process the result of the DataHandler hook processDatamap_afterAllOperations
+ * to notify the user about changes of periods and ask them to send a mail to the visitors.
+ */
+class AskForMailService
+{
+    const TABLE = 'tx_reserve_domain_model_period';
+
+    /**
+     * @var DataHandler
+     */
+    protected $dataHandler;
+
+    /**
+     * @var array
+     */
+    protected $updatedRecords = [];
+
+    public function processDataHandlerResultAfterAllOperations(DataHandler $dataHandler): bool
+    {
+        if (!array_key_exists(self::TABLE, $dataHandler->datamap)) {
+            return false;
+        }
+
+        $this->dataHandler = $dataHandler;
+        $this->checkForUpdatedRecords();
+        if (!empty($this->updatedRecords)) {
+            $this->addJavaScriptAndSettingsToPageRenderer();
+        }
+
+        return true;
+    }
+
+    protected function checkForUpdatedRecords()
+    {
+        $checkFields = ['begin', 'end', 'date'];
+        $updatedRecords = [];
+        foreach ($this->dataHandler->getHistoryRecords() as $recordId => $historyRecord) {
+            if (strpos($recordId, self::TABLE) === false) {
+                continue;
+            }
+            foreach ($checkFields as $checkField) {
+                if (
+                    array_key_exists($checkField, $historyRecord['oldRecord'])
+                    && $historyRecord['oldRecord'][$checkField] !== $historyRecord['newRecord'][$checkField]
+                ) {
+                    // value has been updated
+                    $updatedRecords[] = (int)str_replace(self::TABLE . ':', '', $recordId);
+                }
+            }
+        }
+        $this->updatedRecords = $updatedRecords;
+    }
+
+    protected function addJavaScriptAndSettingsToPageRenderer()
+    {
+        /** @var PageRenderer $pageRenderer */
+        $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+        $pageRenderer->addJsInlineCode(
+            'Require-JS-Module-TYPO3/CMS/Reserve/Backend/AskForMailAfterEditModule',
+            'require(["TYPO3/CMS/Reserve/Backend/AskForMailAfterEditModule"]);'
+        );
+
+        // get pid of first period and create email record on same pid
+        /** @var \TYPO3\CMS\Core\Database\Connection $connection */
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable(self::TABLE);
+        $row = $connection->select(['pid'], self::TABLE, ['uid' => current($this->updatedRecords)])->fetch();
+
+        $params = [
+            'edit' => ['tx_reserve_domain_model_email' => [$row['pid'] => 'new']],
+            'returnUrl' => '',
+            'defVals' => ['tx_reserve_domain_model_email' => ['subject' => 'Test', 'periods' => implode(',', $this->updatedRecords)]]
+        ];
+        $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+        $pageRenderer->addInlineSettingArray(
+            'reserve.modals',
+            [[
+                'title' => 'Replace by title ;)',
+                'message' => 'The time of at least one period has changed! Do you want to compose a mail to the affected visitors?',
+                'uri' => (string)$uriBuilder->buildUriFromRoute('record_edit', $params)
+            ]]
+        );
+    }
+}

--- a/Classes/Service/CancellationService.php
+++ b/Classes/Service/CancellationService.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Service;
@@ -23,6 +17,7 @@ use JWeiland\Reserve\Utility\FluidUtility;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3\CMS\Fluid\View\StandaloneView;
 
 /**
@@ -71,7 +66,7 @@ class CancellationService implements SingletonInterface
             $standaloneView->setTemplate('Cancellation');
             GeneralUtility::makeInstance(MailService::class)->sendMailToCustomer(
                 $order,
-                'Your cancellation',
+                LocalizationUtility::translate('mail.cancellation.subject', 'reserve'),
                 $standaloneView->render()
             );
         }

--- a/Classes/Service/CancellationService.php
+++ b/Classes/Service/CancellationService.php
@@ -20,7 +20,6 @@ namespace JWeiland\Reserve\Service;
 use JWeiland\Reserve\Domain\Model\Order;
 use JWeiland\Reserve\Utility\CacheUtility;
 use JWeiland\Reserve\Utility\FluidUtility;
-use JWeiland\Reserve\Utility\MailUtility;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
@@ -70,7 +69,7 @@ class CancellationService implements SingletonInterface
             $standaloneView->assignMultiple(['order' => $order, 'reason' => $reason]);
             $standaloneView->assignMultiple($vars);
             $standaloneView->setTemplate('Cancellation');
-            MailUtility::sendMailToCustomer(
+            GeneralUtility::makeInstance(MailService::class)->sendMailToCustomer(
                 $order,
                 'Your cancellation',
                 $standaloneView->render()

--- a/Classes/Service/CheckoutService.php
+++ b/Classes/Service/CheckoutService.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Service;

--- a/Classes/Service/CheckoutService.php
+++ b/Classes/Service/CheckoutService.php
@@ -22,7 +22,6 @@ use JWeiland\Reserve\Domain\Model\Reservation;
 use JWeiland\Reserve\Utility\CacheUtility;
 use JWeiland\Reserve\Utility\CheckoutUtility;
 use JWeiland\Reserve\Utility\FluidUtility;
-use JWeiland\Reserve\Utility\MailUtility;
 use JWeiland\Reserve\Utility\OrderSessionUtility;
 use JWeiland\Reserve\Utility\QrCodeUtility;
 use TYPO3\CMS\Core\Mail\MailMessage;
@@ -88,7 +87,7 @@ class CheckoutService
 
     public function sendConfirmationMail(Order $order): bool
     {
-        return MailUtility::sendMailToCustomer(
+        return GeneralUtility::makeInstance(MailService::class)->sendMailToCustomer(
             $order,
             $order->getBookedPeriod()->getFacility()->getConfirmationMailSubject(),
             FluidUtility::replaceMarkerByRenderedTemplate(
@@ -112,7 +111,7 @@ class CheckoutService
 
     public function sendReservationMail(Order $order)
     {
-        return MailUtility::sendMailToCustomer(
+        return GeneralUtility::makeInstance(MailService::class)->sendMailToCustomer(
             $order,
             $order->getBookedPeriod()->getFacility()->getReservationMailSubject(),
             FluidUtility::replaceMarkerByRenderedTemplate(

--- a/Classes/Service/CheckoutService.php
+++ b/Classes/Service/CheckoutService.php
@@ -98,7 +98,7 @@ class CheckoutService
             )
         );
     }
-‚
+
     public function confirm(Order $order): bool
     {
         $success = true;
@@ -120,8 +120,8 @@ class CheckoutService
                 $order->getBookedPeriod()->getFacility()->getReservationMailHtml(),
                 ['order' => $order]
             ),
-            function(Order $order, string $subject, string $bodyHtml, MailMessage $mailMessage, bool $isSymfonyEmail) {
-                foreach ($order->getReservations() as $reservation) {
+            function(array $data, string $subject, string $bodyHtml, MailMessage $mailMessage, bool $isSymfonyEmail) {
+                 foreach ($data['order']->getReservations() as $reservation) {
                     $qrCode = QrCodeUtility::generateQrCode($reservation);
                     if ($isSymfonyEmail) {
                         $mailMessage->attach($qrCode->writeString(), $reservation->getCode(), $qrCode->getContentType());

--- a/Classes/Service/CheckoutService.php
+++ b/Classes/Service/CheckoutService.php
@@ -29,7 +29,6 @@ use TYPO3\CMS\Core\Mail\MailMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
-use TYPO3\CMS\Fluid\View\StandaloneView;
 
 class CheckoutService
 {
@@ -92,7 +91,7 @@ class CheckoutService
         return MailUtility::sendMailToCustomer(
             $order,
             $order->getBookedPeriod()->getFacility()->getConfirmationMailSubject(),
-            $this->replaceMarkerByRenderedTemplate(
+            FluidUtility::replaceMarkerByRenderedTemplate(
                 '###ORDER_DETAILS###',
                 'Confirmation',
                 $order->getBookedPeriod()->getFacility()->getConfirmationMailHtml(),
@@ -100,7 +99,7 @@ class CheckoutService
             )
         );
     }
-
+‚
     public function confirm(Order $order): bool
     {
         $success = true;
@@ -116,7 +115,7 @@ class CheckoutService
         return MailUtility::sendMailToCustomer(
             $order,
             $order->getBookedPeriod()->getFacility()->getReservationMailSubject(),
-            $this->replaceMarkerByRenderedTemplate(
+            FluidUtility::replaceMarkerByRenderedTemplate(
                 '###RESERVATION###',
                 'Reservation',
                 $order->getBookedPeriod()->getFacility()->getReservationMailHtml(),
@@ -138,26 +137,5 @@ class CheckoutService
                 }
             }
         );
-    }
-
-    /**
-     * @param string $marker content to replace e.g. ###MY_MARKER###
-     * @param string $template fluid template name lowercase!
-     * @param string $content string which may contain $marker
-     * @param array $vars additional vars for the fluid template
-     * @return string
-     */
-    protected function replaceMarkerByRenderedTemplate(
-        string $marker,
-        string $template,
-        string $content,
-        array $vars = []
-    ): string {
-        /** @var StandaloneView $standaloneView */
-        $standaloneView = GeneralUtility::makeInstance(StandaloneView::class);
-        FluidUtility::configureStandaloneViewForMailing($standaloneView);
-        $standaloneView->assignMultiple($vars);
-        $standaloneView->setTemplate($template);
-        return str_replace($marker, $standaloneView->render(), $content);
     }
 }

--- a/Classes/Service/MailService.php
+++ b/Classes/Service/MailService.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Service;

--- a/Classes/Service/MailService.php
+++ b/Classes/Service/MailService.php
@@ -15,18 +15,19 @@ declare(strict_types=1);
  * The TYPO3 project - inspiring people to share!
  */
 
-namespace JWeiland\Reserve\Utility;
+namespace JWeiland\Reserve\Service;
 
 use JWeiland\Reserve\Domain\Model\Order;
 use TYPO3\CMS\Core\Mail\MailMessage;
+use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
- * Utility to send mails
+ * Service to send mails
  */
-class MailUtility
+class MailService implements SingletonInterface
 {
-    public static function sendMailToCustomer(Order $order, string $subject, string $bodyHtml, \Closure $postProcess = null): bool
+    public function sendMailToCustomer(Order $order, string $subject, string $bodyHtml, \Closure $postProcess = null): bool
     {
         /** @var MailMessage $mail */
         $mail = GeneralUtility::makeInstance(MailMessage::class);

--- a/Classes/Utility/AbstractUtility.php
+++ b/Classes/Utility/AbstractUtility.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Utility;

--- a/Classes/Utility/CacheUtility.php
+++ b/Classes/Utility/CacheUtility.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Utility;

--- a/Classes/Utility/CheckoutUtility.php
+++ b/Classes/Utility/CheckoutUtility.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Utility;

--- a/Classes/Utility/FluidUtility.php
+++ b/Classes/Utility/FluidUtility.php
@@ -67,4 +67,25 @@ class FluidUtility
         }
         return static::$configurationManager;
     }
+
+    /**
+     * @param string $marker content to replace e.g. ###MY_MARKER###
+     * @param string $template fluid template name lowercase!
+     * @param string $content string which may contain $marker
+     * @param array $vars additional vars for the fluid template
+     * @return string
+     */
+    public static function replaceMarkerByRenderedTemplate(
+        string $marker,
+        string $template,
+        string $content,
+        array $vars = []
+    ): string {
+        /** @var StandaloneView $standaloneView */
+        $standaloneView = GeneralUtility::makeInstance(StandaloneView::class);
+        static::configureStandaloneViewForMailing($standaloneView);
+        $standaloneView->assignMultiple($vars);
+        $standaloneView->setTemplate($template);
+        return str_replace($marker, $standaloneView->render(), $content);
+    }
 }

--- a/Classes/Utility/FluidUtility.php
+++ b/Classes/Utility/FluidUtility.php
@@ -53,7 +53,7 @@ class FluidUtility
             ?? ['EXT:reserve/Resources/Private/Layouts/']
         );
         $standaloneView->setPartialRootPaths(
-            $extbaseFrameworkConfiguration['view']['layoutRootPaths']
+            $extbaseFrameworkConfiguration['view']['partialRootPaths']
             ?? ['EXT:reserve/Resources/Private/Partials/']
         );
         $standaloneView->getRenderingContext()->setControllerName('Mail');

--- a/Classes/Utility/FluidUtility.php
+++ b/Classes/Utility/FluidUtility.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Utility;

--- a/Classes/Utility/OrderSessionUtility.php
+++ b/Classes/Utility/OrderSessionUtility.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Utility;

--- a/Classes/Utility/QrCodeUtility.php
+++ b/Classes/Utility/QrCodeUtility.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\Utility;

--- a/Classes/ViewHelpers/QrCodeViewHelper.php
+++ b/Classes/ViewHelpers/QrCodeViewHelper.php
@@ -3,16 +3,10 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
+ * This file is part of the package jweiland/reserve.
  *
  * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * LICENSE file that was distributed with this source code.
  */
 
 namespace JWeiland\Reserve\ViewHelpers;

--- a/Configuration/Commands.php
+++ b/Configuration/Commands.php
@@ -6,4 +6,7 @@ return [
     'reserve:remove_inactive_orders' => [
         'class' => \JWeiland\Reserve\Command\RemoveInactiveOrdersCommand::class
     ],
+    'reserve:send_mails' => [
+        'class' => \JWeiland\Reserve\Command\SendMailsCommand::class
+    ]
 ];

--- a/Configuration/TCA/tx_reserve_domain_model_email.php
+++ b/Configuration/TCA/tx_reserve_domain_model_email.php
@@ -1,0 +1,153 @@
+<?php
+
+$localLangGeneral = 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf';
+if (!is_file(\TYPO3\CMS\Core\Utility\PathUtility::getAbsoluteWebPath($localLangGeneral))) {
+    $localLangGeneral = 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf';
+}
+
+return [
+    'ctrl' => [
+        'label' => 'subject',
+        'sortby' => 'sorting',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'title' => 'LLL:EXT:reserve/Resources/Private/Language/locallang_db.xlf:tx_reserve_domain_model_email',
+        'delete' => 'deleted',
+        'transOrigPointerField' => 'l18n_parent',
+        'transOrigDiffSourceField' => 'l18n_diffsource',
+        'languageField' => 'sys_language_uid',
+        'translationSource' => 'l18n_source',
+        'enablecolumns' => [
+            'disabled' => 'hidden'
+        ],
+        'searchFields' => 'subject',
+//        'typeicon_classes' => [
+//            'default' => 'tx_reserve_domain_model_facility'
+//        ]
+    ],
+    'columns' => [
+        'hidden' => [
+            'exclude' => true,
+            'label' => $localLangGeneral . ':LGL.visible',
+            'config' => [
+                'type' => 'check',
+                'renderType' => (function() {
+                    return class_exists(\TYPO3\CMS\Backend\Form\Element\CheckboxToggleElement::class) ? 'checkboxToggle' : null;
+                })(),
+                'items' => [
+                    [
+                        0 => '',
+                        1 => '',
+                        'invertStateDisplay' => true
+                    ]
+                ],
+            ]
+        ],
+        'sys_language_uid' => [
+            'exclude' => true,
+            'label' => $localLangGeneral . ':LGL.language',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'special' => 'languages',
+                'items' => [
+                    [
+                        $localLangGeneral . ':LGL.allLanguages',
+                        -1,
+                        'flags-multiple'
+                    ],
+                ],
+                'default' => 0,
+            ]
+        ],
+        'l18n_parent' => [
+            'displayCond' => 'FIELD:sys_language_uid:>:0',
+            'label' => $localLangGeneral . ':LGL.l18n_parent',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    [
+                        '',
+                        0
+                    ]
+                ],
+                'foreign_table' => 'tx_reserve_domain_model_facility',
+                'foreign_table_where' => 'AND tx_reserve_domain_model_facility.pid=###CURRENT_PID### AND tx_reserve_domain_model_facility.sys_language_uid IN (-1,0)',
+                'default' => 0
+            ]
+        ],
+        'l18n_source' => [
+            'config' => [
+                'type' => 'passthrough'
+            ]
+        ],
+        'subject' => [
+            'label' => 'LLL:EXT:reserve/Resources/Private/Language/locallang_db.xlf:tx_reserve_domain_model_email.subject',
+            'config' => [
+                'type' => 'input',
+                'size' => 50,
+                'max' => 255,
+                'eval' => 'trim,required'
+            ],
+        ],
+        'body' => [
+            'label' => 'LLL:EXT:reserve/Resources/Private/Language/locallang_db.xlf:tx_reserve_domain_model_email.body',
+            'config' => [
+                'type' => 'text',
+                'enableRichtext' => true,
+                'default' => <<<DEFAULT_CONFIRMATION
+<p>Dear visitor,</p>
+<p>we changed some details of your booked time period!</p>
+
+<p>Updated reservation data:</p>
+<p>###RESERVATION###</p>
+DEFAULT_CONFIRMATION
+                ,
+                'eval' => 'trim,required',
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true
+                ]
+            ]
+        ],
+        'periods' => [
+            'label' => 'LLL:EXT:reserve/Resources/Private/Language/locallang_db.xlf:tx_reserve_domain_model_email.periods',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'db',
+                'allowed' => 'tx_reserve_domain_model_period',
+                'fieldControl' => [
+                    'editPopup' => [
+                        'disabled' => true,
+                    ],
+                    'addRecord' => [
+                        'disabled' => true,
+                    ],
+                    'listModule' => [
+                        'disabled' => false,
+                    ],
+                ],
+                'minitems' => 1
+            ],
+        ],
+    ],
+    'types' => [
+        '1' => [
+            'showitem' => 'subject,body,periods,--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,--palette--;;hidden,
+            --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,--palette--;;language'
+        ],
+    ],
+    'palettes' => [
+        'hidden' => [
+            'showitem' => '
+                hidden;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:field.default.hidden
+            ',
+        ],
+        'language' => [
+            'showitem' => '
+                sys_language_uid;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:sys_language_uid_formlabel,l18n_parent
+            ',
+        ],
+    ]
+];

--- a/Configuration/TCA/tx_reserve_domain_model_email.php
+++ b/Configuration/TCA/tx_reserve_domain_model_email.php
@@ -34,9 +34,7 @@ return [
             'label' => $localLangGeneral . ':LGL.visible',
             'config' => [
                 'type' => 'check',
-                'renderType' => (function() {
-                    return class_exists(\TYPO3\CMS\Backend\Form\Element\CheckboxToggleElement::class) ? 'checkboxToggle' : null;
-                })(),
+                'renderType' => 'reserveCheckboxToggle',
                 'items' => [
                     [
                         0 => '',
@@ -182,9 +180,7 @@ return [
             'label' => 'LLL:EXT:reserve/Resources/Private/Language/locallang_db.xlf:tx_reserve_domain_model_email.locked',
             'config' => [
                 'type' => 'check',
-                'renderType' => (function() {
-                    return class_exists(\TYPO3\CMS\Backend\Form\Element\CheckboxToggleElement::class) ? 'checkboxToggle' : null;
-                })(),
+                'renderType' => 'reserveCheckboxToggle',
                 'readOnly' => true
             ],
         ],

--- a/Configuration/TCA/tx_reserve_domain_model_email.php
+++ b/Configuration/TCA/tx_reserve_domain_model_email.php
@@ -22,9 +22,11 @@ return [
             'disabled' => 'hidden'
         ],
         'searchFields' => 'subject',
+        // todo: add icon for email records
 //        'typeicon_classes' => [
-//            'default' => 'tx_reserve_domain_model_facility'
-//        ]
+//            'default' => 'tx_reserve_domain_model_email'
+//        ],
+        'type' => 'receiver_type',
     ],
     'columns' => [
         'hidden' => [
@@ -73,8 +75,8 @@ return [
                         0
                     ]
                 ],
-                'foreign_table' => 'tx_reserve_domain_model_facility',
-                'foreign_table_where' => 'AND tx_reserve_domain_model_facility.pid=###CURRENT_PID### AND tx_reserve_domain_model_facility.sys_language_uid IN (-1,0)',
+                'foreign_table' => 'tx_reserve_domain_model_email',
+                'foreign_table_where' => 'AND tx_reserve_domain_model_email.pid=###CURRENT_PID### AND tx_reserve_domain_model_email.sys_language_uid IN (-1,0)',
                 'default' => 0
             ]
         ],
@@ -97,18 +99,63 @@ return [
             'config' => [
                 'type' => 'text',
                 'enableRichtext' => true,
-                'default' => <<<DEFAULT_CONFIRMATION
-<p>Dear visitor,</p>
-<p>we changed some details of your booked time period!</p>
-
-<p>Updated reservation data:</p>
-<p>###RESERVATION###</p>
-DEFAULT_CONFIRMATION
-                ,
                 'eval' => 'trim,required',
                 'behaviour' => [
                     'allowLanguageSynchronization' => true
                 ]
+            ]
+        ],
+        'receiver_type' => [
+            'label' => 'LLL:EXT:reserve/Resources/Private/Language/locallang_db.xlf:tx_reserve_domain_model_email.receiver_type',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'default' => \JWeiland\Reserve\Domain\Model\Email::RECEIVER_TYPE_PERIODS,
+                'items' => [
+                    ['LLL:EXT:reserve/Resources/Private/Language/locallang_db.xlf:tx_reserve_domain_model_email.receiver_type.0', \JWeiland\Reserve\Domain\Model\Email::RECEIVER_TYPE_PERIODS],
+                    ['LLL:EXT:reserve/Resources/Private/Language/locallang_db.xlf:tx_reserve_domain_model_email.receiver_type.1', \JWeiland\Reserve\Domain\Model\Email::RECEIVER_TYPE_MANUAL],
+                ],
+            ]
+        ],
+        'from_name' => [
+            'label' => 'LLL:EXT:reserve/Resources/Private/Language/locallang_db.xlf:tx_reserve_domain_model_email.from_name',
+            'config' => [
+                'type' => 'input',
+                'size' => 50,
+                'eval' => 'trim',
+            ],
+        ],
+        'from_email' => [
+            'label' => 'LLL:EXT:reserve/Resources/Private/Language/locallang_db.xlf:tx_reserve_domain_model_email.from_email',
+            'config' => [
+                'type' => 'input',
+                'size' => 50,
+                'eval' => 'email',
+            ],
+        ],
+        'reply_to_name' => [
+            'label' => 'LLL:EXT:reserve/Resources/Private/Language/locallang_db.xlf:tx_reserve_domain_model_email.reply_to_name',
+            'config' => [
+                'type' => 'input',
+                'size' => 50,
+                'eval' => 'trim',
+            ],
+        ],
+        'reply_to_email' => [
+            'label' => 'LLL:EXT:reserve/Resources/Private/Language/locallang_db.xlf:tx_reserve_domain_model_email.reply_to_email',
+            'config' => [
+                'type' => 'input',
+                'size' => 50,
+                'eval' => 'email',
+            ],
+        ],
+        'custom_receivers' => [
+            'label' => 'LLL:EXT:reserve/Resources/Private/Language/locallang_db.xlf:tx_reserve_domain_model_email.custom_receivers',
+            'config' => [
+                'type' => 'text',
+                'cols' => 40,
+                'rows' => 15,
+                'eval' => 'required'
             ]
         ],
         'periods' => [
@@ -146,12 +193,22 @@ DEFAULT_CONFIRMATION
         ]
     ],
     'types' => [
-        '1' => [
-            'showitem' => 'subject,body,periods,locked,command_data,--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,--palette--;;hidden,
+        \JWeiland\Reserve\Domain\Model\Email::RECEIVER_TYPE_PERIODS => [
+            'showitem' => 'subject,body,receiver_type,periods,locked,command_data,--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,--palette--;;hidden,
             --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,--palette--;;language'
         ],
+        \JWeiland\Reserve\Domain\Model\Email::RECEIVER_TYPE_MANUAL => [
+            'showitem' => 'subject,body,receiver_type,--palette--;;mail_from,--palette--;;reply_to,custom_receivers,locked,command_data,--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,--palette--;;hidden,
+            --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,--palette--;;language'
+        ]
     ],
     'palettes' => [
+        'mail_from' => [
+            'showitem' => 'from_name,from_email'
+        ],
+        'reply_to' => [
+            'showitem' => 'reply_to_name,reply_to_email'
+        ],
         'hidden' => [
             'showitem' => '
                 hidden;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:field.default.hidden

--- a/Configuration/TCA/tx_reserve_domain_model_email.php
+++ b/Configuration/TCA/tx_reserve_domain_model_email.php
@@ -131,10 +131,23 @@ DEFAULT_CONFIRMATION
                 'minitems' => 1
             ],
         ],
+        'locked' => [
+            'label' => 'LLL:EXT:reserve/Resources/Private/Language/locallang_db.xlf:tx_reserve_domain_model_email.locked',
+            'config' => [
+                'type' => 'check',
+                'renderType' => (function() {
+                    return class_exists(\TYPO3\CMS\Backend\Form\Element\CheckboxToggleElement::class) ? 'checkboxToggle' : null;
+                })(),
+                'readOnly' => true
+            ],
+        ],
+        'command_data' => [
+            'config' => ['type' => 'passthrough']
+        ]
     ],
     'types' => [
         '1' => [
-            'showitem' => 'subject,body,periods,--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,--palette--;;hidden,
+            'showitem' => 'subject,body,periods,locked,command_data,--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,--palette--;;hidden,
             --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,--palette--;;language'
         ],
     ],

--- a/Configuration/TCA/tx_reserve_domain_model_facility.php
+++ b/Configuration/TCA/tx_reserve_domain_model_facility.php
@@ -32,9 +32,7 @@ return [
             'label' => $localLangGeneral . ':LGL.visible',
             'config' => [
                 'type' => 'check',
-                'renderType' => (function() {
-                    return class_exists(\TYPO3\CMS\Backend\Form\Element\CheckboxToggleElement::class) ? 'checkboxToggle' : null;
-                })(),
+                'renderType' => 'reserveCheckboxToggle',
                 'items' => [
                     [
                         0 => '',

--- a/Configuration/TCA/tx_reserve_domain_model_order.php
+++ b/Configuration/TCA/tx_reserve_domain_model_order.php
@@ -37,9 +37,7 @@ return [
             'label' => $localLangGeneral . ':LGL.visible',
             'config' => [
                 'type' => 'check',
-                'renderType' => (function() {
-                    return class_exists(\TYPO3\CMS\Backend\Form\Element\CheckboxToggleElement::class) ? 'checkboxToggle' : null;
-                })(),
+                'renderType' => 'reserveCheckboxToggle',
                 'items' => [
                     [
                         0 => '',
@@ -115,9 +113,7 @@ return [
             'label' => 'LLL:EXT:reserve/Resources/Private/Language/locallang_db.xlf:tx_reserve_domain_model_order.activated',
             'config' => [
                 'type' => 'check',
-                'renderType' => (function() {
-                    return class_exists(\TYPO3\CMS\Backend\Form\Element\CheckboxToggleElement::class) ? 'checkboxToggle' : null;
-                })(),
+                'renderType' => 'reserveCheckboxToggle',
             ],
         ],
         'activation_code' => [

--- a/Configuration/TCA/tx_reserve_domain_model_period.php
+++ b/Configuration/TCA/tx_reserve_domain_model_period.php
@@ -34,9 +34,7 @@ return [
             'label' => $localLangGeneral . ':LGL.visible',
             'config' => [
                 'type' => 'check',
-                'renderType' => (function() {
-                    return class_exists(\TYPO3\CMS\Backend\Form\Element\CheckboxToggleElement::class) ? 'checkboxToggle' : null;
-                })(),
+                'renderType' => 'reserveCheckboxToggle',
                 'items' => [
                     [
                         0 => '',

--- a/Configuration/TCA/tx_reserve_domain_model_reservation.php
+++ b/Configuration/TCA/tx_reserve_domain_model_reservation.php
@@ -32,9 +32,7 @@ return [
             'label' => $localLangGeneral . ':LGL.visible',
             'config' => [
                 'type' => 'check',
-                'renderType' => (function() {
-                    return class_exists(\TYPO3\CMS\Backend\Form\Element\CheckboxToggleElement::class) ? 'checkboxToggle' : null;
-                })(),
+                'renderType' => 'reserveCheckboxToggle',
                 'items' => [
                     [
                         0 => '',
@@ -107,9 +105,7 @@ return [
             'label' => 'LLL:EXT:reserve/Resources/Private/Language/locallang_db.xlf:tx_reserve_domain_model_reservation.used',
             'config' => [
                 'type' => 'check',
-                'renderType' => (function() {
-                    return class_exists(\TYPO3\CMS\Backend\Form\Element\CheckboxToggleElement::class) ? 'checkboxToggle' : null;
-                })(),
+                'renderType' => 'reserveCheckboxToggle',
             ],
         ],
     ],

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -178,6 +178,15 @@
 			<trans-unit id="flashMessage.clearedCacheForFacility">
 				<target>Der Cache für die %s Listenansicht(en) im Frontend wurde erfolgreich geleert.</target>
 			</trans-unit>
+			<trans-unit id="modal.periodAskForMail.title">
+				<target>Mindestens ein Zeitblock wurde geupdated</target>
+			</trans-unit>
+			<trans-unit id="modal.periodAskForMail.message">
+				<target>Die Zeit von mindestens einem Zeitblock wurde verändert. Möchten Sie eine E-Mail verfassen, um die betroffenen Besucher zu informieren?</target>
+			</trans-unit>
+			<trans-unit id="modal.periodAskForMail.button.writeMail">
+				<target>E-Mail verfassen</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -184,8 +184,27 @@
 			<trans-unit id="modal.periodAskForMail.message">
 				<target>Die Zeit von mindestens einem Zeitblock wurde verändert. Möchten Sie eine E-Mail verfassen, um die betroffenen Besucher zu informieren?</target>
 			</trans-unit>
-			<trans-unit id="modal.periodAskForMail.button.writeMail">
+			<trans-unit id="modal.button.writeMail">
 				<target>E-Mail verfassen</target>
+			</trans-unit>
+			<trans-unit id="modal.periodAskForMailAfterDeletion.title">
+				<target>Mindestens ein Zeitblock wurde entfernt</target>
+			</trans-unit>
+			<trans-unit id="modal.periodAskForMailAfterDeletion.message">
+				<target>Möchten Sie die Kunden über die Streichung der reservierten Tickets informieren?</target>
+			</trans-unit>
+
+			<trans-unit id="email.body.afterPeriodUpdate">
+				<target><![CDATA[<p>Lieber Besucher,</p>
+<p>wir haben ein paar Änderungen an den Zeiten ihrer gebuchten Tickets vorgenommen.</p>
+
+<p>Aktualisierte Reservierungszeit:</p>
+<p>###RESERVATION###</p>]]></target>
+			</trans-unit>
+			<trans-unit id="email.body.afterPeriodDeletion">
+				<target><![CDATA[<p>Lieber Besucher,</p>
+<p>es tut uns sehr leid, aber Ihr gebuchtes Ticket wurde leider gestrichen!</p>
+]]></target>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -88,6 +88,9 @@
 			<trans-unit id="mail.salutation">
 				<target>Sehr geehrter Besucher,</target>
 			</trans-unit>
+			<trans-unit id="mail.cancellation.subject">
+				<target>Stornierung der Reservierung</target>
+			</trans-unit>
 			<trans-unit id="mail.cancellation.inactive">
 				<target>die Reservierung für %s  wurde storniert, da sie nicht innerhalb von %d Minuten aktiviert wurde.</target>
 			</trans-unit>

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -123,6 +123,18 @@
 			<trans-unit id="tx_reserve_domain_model_reservation.used">
 				<target>Eingelöst</target>
 			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email">
+				<target>E-Mail</target>
+			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.subject">
+				<target>Betreff</target>
+			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.body">
+				<target>Nachricht</target>
+			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.periods">
+				<target>Sende Mail an Gäste der ausgewählten Zeitblöcke</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -135,6 +135,9 @@
 			<trans-unit id="tx_reserve_domain_model_email.periods">
 				<target>Sende Mail an Gäste der ausgewählten Zeitblöcke</target>
 			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.locked">
+				<target>E-Mails werden aktuell verschickt</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -138,6 +138,30 @@
 			<trans-unit id="tx_reserve_domain_model_email.locked">
 				<target>E-Mails werden aktuell verschickt</target>
 			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.receiver_type">
+				<source>Receiver type</source>
+			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.receiver_type.0">
+				<target>Sende Mail an Gäste der ausgewählten Zeitblöcke</target>
+			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.receiver_type.1">
+				<target>E-Mail Adressen händisch eintragen</target>
+			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.custom_receivers">
+				<target>Empfänger (kommaseparierte Liste von E-Mail Adressen)</target>
+			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.from_name">
+				<target>Absender Name (optional)</target>
+			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.from_email">
+				<target>Absender E-Mail Adresse (optional)</target>
+			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.reply_to_name">
+				<target>Antwortadresse Name (optional)</target>
+			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.reply_to_email">
+				<target>Antwortadresse E-Mail (optional)</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -184,8 +184,27 @@
 			<trans-unit id="modal.periodAskForMail.message">
 				<source>The time of at least one period was changed! Do you want to write an e-mail to inform the affected visitors?</source>
 			</trans-unit>
-			<trans-unit id="modal.periodAskForMail.button.writeMail">
+			<trans-unit id="modal.button.writeMail">
 				<source>Write e-mail</source>
+			</trans-unit>
+			<trans-unit id="modal.periodAskForMailAfterDeletion.title">
+				<source>You deleted at least one period</source>
+			</trans-unit>
+			<trans-unit id="modal.periodAskForMailAfterDeletion.message">
+				<source>Do you want to inform the affected visitors about the cancellation of their reserved tickets?</source>
+			</trans-unit>
+
+			<trans-unit id="email.body.afterPeriodUpdate">
+				<source><![CDATA[<p>Dear visitor,</p>
+<p>we changed some details of your booked time period!</p>
+
+<p>Updated reservation data:</p>
+<p>###RESERVATION###</p>]]></source>
+			</trans-unit>
+			<trans-unit id="email.body.afterPeriodDeletion">
+				<source><![CDATA[<p>Dear visitor,</p>
+<p>we are sorry but your reserved ticket got cancelled!</p>
+]]></source>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -178,6 +178,15 @@
 			<trans-unit id="flashMessage.clearedCacheForFacility">
 				<source>Cleared cache for %s list view(s) in frontend.</source>
 			</trans-unit>
+			<trans-unit id="modal.periodAskForMail.title">
+				<source>You updated at least one period</source>
+			</trans-unit>
+			<trans-unit id="modal.periodAskForMail.message">
+				<source>The time of at least one period was changed! Do you want to write an e-mail to inform the affected visitors?</source>
+			</trans-unit>
+			<trans-unit id="modal.periodAskForMail.button.writeMail">
+				<source>Write e-mail</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -88,6 +88,9 @@
 			<trans-unit id="mail.salutation">
 				<source>Dear visitor,</source>
 			</trans-unit>
+			<trans-unit id="mail.cancellation.subject">
+				<source>Your cancellation</source>
+			</trans-unit>
 			<trans-unit id="mail.cancellation.inactive">
 				<source>your reservation for %s has been cancelled because you have not confirmed it within %d minutes.</source>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -138,6 +138,30 @@
 			<trans-unit id="tx_reserve_domain_model_email.locked">
 				<source>Mails are currently being sent</source>
 			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.receiver_type">
+				<source>Receiver type</source>
+			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.receiver_type.0">
+				<source>Send mail to visitors of selected periods</source>
+			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.receiver_type.1">
+				<source>Write down E-Mail addresses manually</source>
+			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.custom_receivers">
+				<source>Receivers (comma separated list of mail addresses)</source>
+			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.from_name">
+				<source>From name (optional)</source>
+			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.from_email">
+				<source>From email (optional)</source>
+			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.reply_to_name">
+				<source>Reply to name (optional)</source>
+			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.reply_to_email">
+				<source>Reply to email (optional)</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -135,6 +135,9 @@
 			<trans-unit id="tx_reserve_domain_model_email.periods">
 				<source>Send mail to visitors of selected periods</source>
 			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.locked">
+				<source>Mails are currently being sent</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -123,6 +123,18 @@
 			<trans-unit id="tx_reserve_domain_model_reservation.used">
 				<source>Used</source>
 			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email">
+				<source>E-Mail</source>
+			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.subject">
+				<source>Subject</source>
+			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.body">
+				<source>Body</source>
+			</trans-unit>
+			<trans-unit id="tx_reserve_domain_model_email.periods">
+				<source>Send mail to visitors of selected periods</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Partials/Mail/ReservationDetails.html
+++ b/Resources/Private/Partials/Mail/ReservationDetails.html
@@ -2,5 +2,5 @@
 
 <ul>
 	<li><f:translate extensionName="reserve" key="mail.facility" />: {order.bookedPeriod.facility.name}</li>
-	<li><f:translate extensionName="reserve" key="mail.period" />: <f:format.date>{order.bookedPeriod.date}</f:format.date> <f:format.date format="H:i">{order.bookedPeriod.begin}</f:format.date> - <f:format.date format="H:i">{order.bookedPeriod.end}</f:format.date></li>
+	<li><f:translate extensionName="reserve" key="mail.period" />: <f:format.date format="{f:translate(key: 'date_format', extensionName: 'reserve')}">{order.bookedPeriod.date}</f:format.date> <f:format.date format="H:i">{order.bookedPeriod.begin}</f:format.date> - <f:format.date format="H:i">{order.bookedPeriod.end}</f:format.date></li>
 </ul>

--- a/Resources/Private/Partials/Mail/ReservationDetails.html
+++ b/Resources/Private/Partials/Mail/ReservationDetails.html
@@ -1,0 +1,6 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+
+<ul>
+	<li><f:translate extensionName="reserve" key="mail.facility" />: {order.bookedPeriod.facility.name}</li>
+	<li><f:translate extensionName="reserve" key="mail.period" />: <f:format.date>{order.bookedPeriod.date}</f:format.date> <f:format.date format="H:i">{order.bookedPeriod.begin}</f:format.date> - <f:format.date format="H:i">{order.bookedPeriod.end}</f:format.date></li>
+</ul>

--- a/Resources/Private/Templates/Mail/Confirmation.html
+++ b/Resources/Private/Templates/Mail/Confirmation.html
@@ -6,10 +6,7 @@ Variables:
 order: Current order
 pageUid: Page uid which contains the reserve checkout plugin
 --></f:comment>
-<ul>
-	<li><f:translate extensionName="reserve" key="mail.facility" />: {order.bookedPeriod.facility.name}</li>
-	<li><f:translate extensionName="reserve" key="mail.period" />: <f:format.date format="{f:translate(extensionName: 'reserve', key: 'date_format')}">{order.bookedPeriod.date}</f:format.date> <f:format.date format="H:i">{order.bookedPeriod.begin}</f:format.date> - <f:format.date format="H:i">{order.bookedPeriod.end}</f:format.date></li>
-</ul>
+<f:render partial="Mail/ReservationDetails" arguments="{order: order}" />
 
 <f:link.action absolute="true" pageUid="{pageUid}" pluginName="Reservation" extensionName="reserve" controller="Checkout" action="confirm" arguments="{email: order.email, activationCode: order.activationCode}"><f:translate extensionName="reserve" key="mail.confirmation.confirm_link_text" /></f:link.action>
 

--- a/Resources/Private/Templates/Mail/Reservation.html
+++ b/Resources/Private/Templates/Mail/Reservation.html
@@ -7,10 +7,7 @@ order: Current order
 --></f:comment>
 <p><f:translate extensionName="reserve" key="mail.reservation.print_notice" /></p>
 
-<ul>
-	<li><f:translate extensionName="reserve" key="mail.facility" />: {order.bookedPeriod.facility.name}</li>
-	<li><f:translate extensionName="reserve" key="mail.period" />: <f:format.date>{order.bookedPeriod.date}</f:format.date> <f:format.date format="H:i">{order.bookedPeriod.begin}</f:format.date> - <f:format.date format="H:i">{order.bookedPeriod.end}</f:format.date></li>
-</ul>
+<f:render partial="Mail/ReservationDetails" arguments="{order: order}" />
 
 <f:for each="{order.reservations}" as="reservation">
 	<img src="cid:{reservation.code}" title="QR Code" alt="{reservation.code}" style="padding: 40px;"/>

--- a/Resources/Private/Templates/Mail/UpdatedReservation.html
+++ b/Resources/Private/Templates/Mail/UpdatedReservation.html
@@ -1,0 +1,9 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+<f:comment><!--
+The rendered content of this template will be used as ###RESERVATION### marker inside the updated reservation mail.
+
+Variables:
+order: Current order
+--></f:comment>
+<f:render partial="Mail/ReservationDetails" arguments="{order: order}" />
+</html>

--- a/Resources/Public/JavaScript/Backend/AskForMailAfterEditModule.js
+++ b/Resources/Public/JavaScript/Backend/AskForMailAfterEditModule.js
@@ -5,7 +5,7 @@ define(['TYPO3/CMS/Backend/Modal'], function(Modal) {
             content: TYPO3.settings.reserve.showModal.message,
             buttons: [
                 {
-                    text: TYPO3.lang['reserve.modal.periodAskForMail.button.writeMail'],
+                    text: TYPO3.lang['reserve.modal.button.writeMail'],
                     name: 'write-mail',
                     icon: 'content-elements-mailform',
                     active: true,

--- a/Resources/Public/JavaScript/Backend/AskForMailAfterEditModule.js
+++ b/Resources/Public/JavaScript/Backend/AskForMailAfterEditModule.js
@@ -1,22 +1,22 @@
 define(['TYPO3/CMS/Backend/Modal'], function(Modal) {
-    var i = 0;
-    for (i = 0; i < TYPO3.settings.reserve.modals.length; i++) {
+    if (typeof TYPO3.settings.reserve.showModal !== 'undefined') {
         var configuration = {
-            title: TYPO3.settings.reserve.modals[i].title,
-            content: TYPO3.settings.reserve.modals[i].message,
+            title: TYPO3.settings.reserve.showModal.title,
+            content: TYPO3.settings.reserve.showModal.message,
             buttons: [
                 {
-                    text: 'Send mail',
-                    name: 'compose-mail',
+                    text: TYPO3.lang['reserve.modal.periodAskForMail.button.writeMail'],
+                    name: 'write-mail',
                     icon: 'content-elements-mailform',
                     active: true,
                     btnClass: 'btn-primary',
-                    dataAttributes: {
-                        uri: TYPO3.settings.reserve.modals[i].uri
-                    },
-                    trigger: function(event) {
+                    trigger: function() {
+                        // Open new model after current model is fully destroyed!
+                        // Otherwise the modal buttons won't work
+                        Modal.currentModal.on('modal-destroyed', function (event) {
+                            showMailModal(TYPO3.settings.reserve.showModal.uri);
+                        });
                         Modal.currentModal.trigger('modal-dismiss');
-                        showMailModal(event.target.parentElement.dataset['uri']);
                     }
                 }
             ]
@@ -28,10 +28,14 @@ define(['TYPO3/CMS/Backend/Modal'], function(Modal) {
     {
         var configuration = {
             type: Modal.types.iframe,
-            title: 'NOT TRANSLATED YET!: Compose mail for affected visitors...',
             content: uri,
             size: Modal.sizes.large,
         };
         Modal.advanced(configuration);
+        Modal.currentModal.find('.modal-iframe').on('load', function (event) {
+            if (event.target.contentWindow.location.href.includes('#txReserveCloseModal')) {
+                Modal.currentModal.trigger('modal-dismiss');
+            }
+        });
     }
 });

--- a/Resources/Public/JavaScript/Backend/AskForMailAfterEditModule.js
+++ b/Resources/Public/JavaScript/Backend/AskForMailAfterEditModule.js
@@ -1,0 +1,37 @@
+define(['TYPO3/CMS/Backend/Modal'], function(Modal) {
+    var i = 0;
+    for (i = 0; i < TYPO3.settings.reserve.modals.length; i++) {
+        var configuration = {
+            title: TYPO3.settings.reserve.modals[i].title,
+            content: TYPO3.settings.reserve.modals[i].message,
+            buttons: [
+                {
+                    text: 'Send mail',
+                    name: 'compose-mail',
+                    icon: 'content-elements-mailform',
+                    active: true,
+                    btnClass: 'btn-primary',
+                    dataAttributes: {
+                        uri: TYPO3.settings.reserve.modals[i].uri
+                    },
+                    trigger: function(event) {
+                        Modal.currentModal.trigger('modal-dismiss');
+                        showMailModal(event.target.parentElement.dataset['uri']);
+                    }
+                }
+            ]
+        };
+        Modal.advanced(configuration);
+    }
+
+    function showMailModal(uri)
+    {
+        var configuration = {
+            type: Modal.types.iframe,
+            title: 'NOT TRANSLATED YET!: Compose mail for affected visitors...',
+            content: uri,
+            size: Modal.sizes.large,
+        };
+        Modal.advanced(configuration);
+    }
+});

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -86,4 +86,5 @@ foreach ($icons AS $identifier) {
 unset($icons, $iconRegistry);
 
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] = \JWeiland\Reserve\Hooks\DataHandler::class;
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass'][] = \JWeiland\Reserve\Hooks\DataHandler::class;
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-preProcess'][] = \JWeiland\Reserve\Hooks\PageRenderer::class . '->processTxReserveModalUserSetting';

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -86,3 +86,4 @@ foreach ($icons AS $identifier) {
 unset($icons, $iconRegistry);
 
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] = \JWeiland\Reserve\Hooks\DataHandler::class;
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-preProcess'][] = \JWeiland\Reserve\Hooks\PageRenderer::class . '->processTxReserveModalUserSetting';

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -88,3 +88,9 @@ unset($icons, $iconRegistry);
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] = \JWeiland\Reserve\Hooks\DataHandler::class;
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass'][] = \JWeiland\Reserve\Hooks\DataHandler::class;
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-preProcess'][] = \JWeiland\Reserve\Hooks\PageRenderer::class . '->processTxReserveModalUserSetting';
+
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeResolver'][1593430553393] = [
+    'nodeName' => 'reserveCheckboxToggle',
+    'priority' => 50,
+    'class' => \JWeiland\Reserve\Form\Resolver\CheckboxToggleElementResolver::class,
+];

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,8 +1,0 @@
-<?php
-defined('TYPO3_MODE') or die();
-
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_reserve_domain_model_facility');
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_reserve_domain_model_order');
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_reserve_domain_model_period');
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_reserve_domain_model_reservation');
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_reserve_domain_model_email');

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -5,3 +5,4 @@ defined('TYPO3_MODE') or die();
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_reserve_domain_model_order');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_reserve_domain_model_period');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_reserve_domain_model_reservation');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_reserve_domain_model_email');

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -148,6 +148,8 @@ CREATE TABLE tx_reserve_domain_model_email (
 	subject tinytext,
 	body text,
 	periods int(11) DEFAULT '0' NOT NULL,
+	locked int(11) DEFAULT '0' NOT NULL,
+	command_data mediumtext,
 
 	PRIMARY KEY (uid),
 	KEY parent (pid),

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -147,6 +147,12 @@ CREATE TABLE tx_reserve_domain_model_email (
 
 	subject tinytext,
 	body text,
+	receiver_type int(11) DEFAULT '0' NOT NULL,
+	from_name tinytext,
+	from_email tinytext,
+	reply_to_name tinytext,
+	reply_to_email tinytext,
+	custom_receivers text,
 	periods text,
 	locked int(11) DEFAULT '0' NOT NULL,
 	command_data mediumtext,

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -147,7 +147,7 @@ CREATE TABLE tx_reserve_domain_model_email (
 
 	subject tinytext,
 	body text,
-	periods int(11) DEFAULT '0' NOT NULL,
+	periods text,
 	locked int(11) DEFAULT '0' NOT NULL,
 	command_data mediumtext,
 

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -127,3 +127,29 @@ CREATE TABLE tx_reserve_domain_model_reservation (
 	KEY parent (pid),
 	KEY sys_language_uid_l18n_parent (sys_language_uid,l18n_parent)
 );
+
+#
+# Table structure for table 'tx_reserve_domain_model_email'
+#
+CREATE TABLE tx_reserve_domain_model_email (
+	uid int(11) NOT NULL auto_increment,
+	pid int(11) DEFAULT '0' NOT NULL,
+	tstamp int(11) DEFAULT '0' NOT NULL,
+	crdate int(11) DEFAULT '0' NOT NULL,
+	cruser_id int(11) DEFAULT '0' NOT NULL,
+	sys_language_uid int(11) DEFAULT '0' NOT NULL,
+	l18n_parent int(11) DEFAULT '0' NOT NULL,
+	l18n_diffsource mediumtext,
+	l18n_source int(11) DEFAULT '0' NOT NULL,
+	deleted tinyint(4) DEFAULT '0' NOT NULL,
+	hidden tinyint(4) DEFAULT '0' NOT NULL,
+	sorting int(11) DEFAULT '0' NOT NULL,
+
+	subject tinytext,
+	body text,
+	periods int(11) DEFAULT '0' NOT NULL,
+
+	PRIMARY KEY (uid),
+	KEY parent (pid),
+	KEY sys_language_uid_l18n_parent (sys_language_uid,l18n_parent)
+);


### PR DESCRIPTION
If a user updates a period then all visitors should be informed about changes. Now the backend user will be asked if he wants to inform the visitors about those changes using a custom mail text.

![image](https://user-images.githubusercontent.com/1337769/84279490-5de39100-ab36-11ea-80ab-7c94923fd61b.png)

If a user removes a period e.g. inline inside a period, then he will be asked if he wants to inform the visitors about that too.

Fixes #48