### PR TITLE
Ensure returned integer from db is of type integer

### DIFF
--- a/Classes/Domain/Model/Period.php
+++ b/Classes/Domain/Model/Period.php
@@ -318,7 +318,7 @@ class Period extends AbstractEntity
             if ($activeOnly) {
                 $queryBuilder->andWhere($queryBuilder->expr()->eq('o.activated', 1));
             }
-            $this->cache[$cacheIdentifier] = $queryBuilder->execute()->fetchColumn(0);
+            $this->cache[$cacheIdentifier] = (int)$queryBuilder->execute()->fetchColumn(0);
         }
         return $this->cache[$cacheIdentifier];
     }


### PR DESCRIPTION
Some databases might not return expected variable type, e.g. sqlite.
Therefore result is casted to ensure type compatibility.