### PR TITLE
Define extension key in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
 	"extra": {
 		"typo3/cms": {
 			"app-dir": ".build",
-			"web-dir": ".build/public"
+			"web-dir": ".build/public",
+			"extension-key": "reserve"
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
To prevent composer warning during install:

    TYPO3 Extension Package "jweiland/reserve", does not define extension key in composer.json.
    Specifying the extension key will be mandatory in future versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)