### PR TITLE
Reset session after cancel was successful

### DIFF
--- a/Classes/Service/CancellationService.php
+++ b/Classes/Service/CancellationService.php
@@ -14,6 +14,7 @@ namespace JWeiland\Reserve\Service;
 use JWeiland\Reserve\Domain\Model\Order;
 use JWeiland\Reserve\Utility\CacheUtility;
 use JWeiland\Reserve\Utility\FluidUtility;
+use JWeiland\Reserve\Utility\OrderSessionUtility;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
@@ -74,6 +75,9 @@ class CancellationService implements SingletonInterface
             $this->persistenceManager->persistAll();
             CacheUtility::clearPageCachesForPagesWithCurrentFacility($order->getBookedPeriod()->getFacility()->getUid());
         }
+        OrderSessionUtility::unblockNewOrdersForFacilityInCurrentSession(
+            $order->getBookedPeriod()->getFacility()->getUid()
+        );
     }
 
     /**

--- a/Classes/Utility/OrderSessionUtility.php
+++ b/Classes/Utility/OrderSessionUtility.php
@@ -41,6 +41,17 @@ class OrderSessionUtility extends AbstractUtility
         static::getTypoScriptFrontendController()->fe_user->setKey('ses', self::SESSION_KEY, $orders);
     }
 
+    public static function unblockNewOrdersForFacilityInCurrentSession(int $facilityUid)
+    {
+        // [<facility_uid> => <timestamp_of_confirmation>]
+        $orders = [];
+        if (static::getTypoScriptFrontendController()->fe_user->getKey('ses', self::SESSION_KEY)) {
+            $orders = static::getTypoScriptFrontendController()->fe_user->getKey('ses', self::SESSION_KEY);
+        }
+        unset($orders[$facilityUid]);
+        static::getTypoScriptFrontendController()->fe_user->setKey('ses', self::SESSION_KEY, $orders);
+    }
+
     public static function isUserAllowedToOrder(int $facilityUid): bool
     {
         $allowed = true;


### PR DESCRIPTION
Once a user cancels a reservation, he should be allowed to order again.
A user could accident order the wrong time slot. He should not be
prevented from ordering the proper slot, once he canceled the old order.